### PR TITLE
feat: add path as summary to all endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ function init(predefinedSpec) {
     }
     endpoint.methods.forEach(m => {
       spec.paths[path][m.toLowerCase()] = {
+        summary: path,
         consumes: ['application/json'],
         parameters: params.map(p => ({
           name: p,

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -115,7 +115,7 @@ function updateResponses(res, method, chunks) {
   method.responses = method.responses || {};
   method.responses[res.statusCode] = {};
   const contentType = res.get('content-type');
-  if (!contentType || (contentType.indexOf('json') === -1 && contentType.indexOf('text') === -1)) {
+  if (!contentType || contentType.indexOf('json') === -1 && contentType.indexOf('text') === -1) {
     return;
   }
 
@@ -130,7 +130,7 @@ function updateResponses(res, method, chunks) {
     schema = {
       type: type,
       example: type === 'string' ? body : Number(body)
-    }
+    };
   }
   method.responses[res.statusCode].schema = schema;
 }

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -6,7 +6,7 @@ const bodyParser = require('body-parser');
 const generator = require('../index.js');
 
 const MS_TO_STARTUP = 2000;
-const port = 8080;
+const port = 8888;
 const ERROR_RESPONSE_CODE = 500;
 const BASE_PATH = '/api/v1';
 const ERROR_PATH = '/error';
@@ -64,14 +64,15 @@ describe('index.js', () => {
 
   afterAll(() => {
     // console.info(JSON.stringify(generator.getSpec(), null, 2));
-    server.close()
+    server.close();
   });
 
   it('WHEN making GET request to endpoint returning plain text THEN schema filled properly', done => {
-    const path = `/hello`;
+    const path = '/hello';
     request.get(`http://localhost:${port}${path}`, () => {
       const method = generator.getSpec().paths[path].get;
       expect(method.produces).toEqual(['text/plain']);
+      expect(method.summary).toEqual(path);
       expect(method.responses[200].schema.type).toEqual('string');
       expect(method.responses[200].schema.example).toEqual(PLAIN_TEXT_RESPONSE);
       done();
@@ -79,8 +80,8 @@ describe('index.js', () => {
   });
 
   it('WHEN making POST request to routerless endpoint THEN body is documented', done => {
-    const path = `/hello2`;
-    const postData = {"foo": "bar"};
+    const path = '/hello2';
+    const postData = {'foo': 'bar'};
     request({
       url: `http://localhost:${port}${path}`,
       method: 'POST',
@@ -91,6 +92,7 @@ describe('index.js', () => {
       ['consumes', 'produces'].forEach(el =>
         expect(method[el]).toEqual(['application/json'])
       );
+      expect(method.summary).toEqual(path);
       const bodyParam = method.parameters[0];
       expect(bodyParam.in).toEqual('body');
       expect(bodyParam.schema.properties.foo.type).toEqual('string');

--- a/test/lib/processors_tests.js
+++ b/test/lib/processors_tests.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const _ = require('lodash');
 const processors = require('../../lib/processors.js');
 
 describe('processors.js', () => {
@@ -45,7 +45,7 @@ describe('processors.js', () => {
     let method = {};
     processors.processHeaders(req, method, spec);
     expect(method.security.map(s => Object.keys(s)[0])).toEqual(headers);
-    expect(Object.values(spec.securityDefinitions)).toEqual(headers.map(h => ({
+    expect(_.values(spec.securityDefinitions)).toEqual(headers.map(h => ({
       name: h,
       in: 'header',
       type: 'apiKey'


### PR DESCRIPTION
When importing in Postman it was awful without the title (i.e `summary` field), so I added `path` as a default `summary` in all methods. 

- Sorry for the large PR, but the lint you had was with --fix flag.
- I took the liberty of changing the test's port to a non standard 8888 cause it's often being used. 
- I also used `_.values` cause `Object.values` didn't exist on my node 9.x :-)

Thanks Matvey for building this :-) 