### PR TITLE
fix!: Use proper OR operator instead of XOR

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ function updateSchemesAndHost(req) {
 module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval) => {
   app = aApp;
   predefinedSpec = aPredefinedSpec;
-  const writeInterval = aWriteInterval | 10 * 1000;
+  const writeInterval = aWriteInterval || 10 * 1000;
 
   // middleware to handle responses
   app.use((req, res, next) => {


### PR DESCRIPTION
BREAKING CHANGE - this can break previous behaviour and should be marked
as a breaking change, because:

```js
let aWriteInterval = 10;

aWriteInterval |  10 * 1000; // 10010
aWriteInterval || 10 * 1000; // 10
```

You obviously meant to allow changing the write interval instead of
XOR'ing it with a default `10000` one, right?:D

I noticed this just now - I'm trying to automate the openapi docs
generation for production.

This is compatible with #32 & #33!

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>