### PR TITLE
fix!: Remove `setTimeout` from request handling middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,25 +168,22 @@ module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval) => {
     next();
   });
 
-  // make sure we list routes after they are configured
-  setTimeout(() => {
-    // middleware to handle requests
-    app.use((req, res, next) => {
-      try {
-        const methodAndPathKey = getMethod(req);
-        if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
-          const method = methodAndPathKey.method;
-          updateSchemesAndHost(req);
-          processors.processPath(req, method, methodAndPathKey.pathKey);
-          processors.processHeaders(req, method, spec);
-          processors.processBody(req, method);
-          processors.processQuery(req, method);
-        }
-      } catch (e) {}
-      next();
-    });
-    init();
-  }, 0);
+  // middleware to handle requests
+  app.use((req, res, next) => {
+    try {
+      const methodAndPathKey = getMethod(req);
+      if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
+        const method = methodAndPathKey.method;
+        updateSchemesAndHost(req);
+        processors.processPath(req, method, methodAndPathKey.pathKey);
+        processors.processHeaders(req, method, spec);
+        processors.processBody(req, method);
+        processors.processQuery(req, method);
+      }
+    } catch (e) {}
+    next();
+  });
+  init(aApiDocsPath);
 };
 
 module.exports.getSpec = () => {

--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval) => {
       next();
     });
     init();
-  }, 1000);
+  }, 0);
 };
 
 module.exports.getSpec = () => {


### PR DESCRIPTION
Setting the delay to a fixed number is okay, but setting it to `0`
is better - it still ensures that the code runs right once we want it
without any additional delay.

I've tested this & it works just fine.

This is compatible with #33 and #31!

Edit: BREAKING CHANGE

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>