### PR TITLE
feat: Do not delay response handling the first time

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,8 +154,10 @@ module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval) => {
       if (methodAndPathKey && methodAndPathKey.method) {
         processors.processResponse(res, methodAndPathKey.method);
       }
+      let firstTime = true;
       const ts = new Date().getTime();
-      if (aPath && ts - lastRecordTime > writeInterval) {
+      if (firstTime || aPath && ts - lastRecordTime > writeInterval) {
+        firstTime = false;
         lastRecordTime = ts;
         fs.writeFile(aPath, JSON.stringify(spec, null, 2), 'utf8', err => {
           const fullPath = path.resolve(aPath);


### PR DESCRIPTION
Previously, you'd have to wait for `aWriteInterval` ms before the first
response handling happens.
This would also delay the creation of the spec's file.

Now, it's not delayed for the first time, just like it should.

I tested this & it works perfectly.

This is compatible with #31 & #32!

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>