### PR TITLE
Create `onWriteCallback` functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function updateSchemesAndHost(req) {
   }
 }
 
-module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval, aApiDocsPath = 'api-docs') => {
+module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval, aApiDocsPath = 'api-docs', onWriteCallback = () => {}) => {
   app = aApp;
   predefinedSpec = aPredefinedSpec;
   const writeInterval = aWriteInterval || 10 * 1000;
@@ -163,6 +163,12 @@ module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval, aApiDocsPat
           const fullPath = path.resolve(aPath);
           if (err) {
             throw new Error(`Cannot store the specification into ${fullPath} because of ${err.message}`);
+          }
+          try {
+            onWriteCallback();
+          } catch (e) {
+            console.error('Failed in the `onWriteCallback()` - check your stuff!');
+            throw new Error(err);
           }
         });
       }


### PR DESCRIPTION
I want to do some modifications everytime the file is updated, so
allowing the user to create a callback once the file is written is very
useful.

I tried writing tests for this but couldn't figure out how - maybe one
should create a file inside the callback and in the tests check if the
file was created to indicate that stuff works. After that - delete the
temp file.

---

I think we could also allow something like `preWrite` callback,
providing the spec that would be written.

This brings attention to another issue - we should definitely start
using an object for all the options, because this is already kinda
bloated, and it could get even more.

See https://github.com/mpashkovskiy/express-oas-generator/issues/35

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>