### PR TITLE
Allow applying middleware individually, document type definitions & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ let app = express();
 /** do other stuff with `app` */
 
 /** place this as the last middleware */
-+expressOasGenerator.injectRequestMiddleware(app);
++expressOasGenerator.handleRequests(app);
 
 app.listen(PORT);
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Instead of using a single `init` handler, we'll use 2 separate ones - one for **
 let app = express();
 
 -expressOasGenerator.init(app, {});
-+expressOasGenerator.injectResponseMiddleware(app, {});
++expressOasGenerator.handleResponses(app, {});
 
 /** do other stuff with `app` */
 

--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ let app = express();
 
 /** do other stuff with `app` */
 
-app.listen(PORT, () => {
-+	expressOasGenerator.injectRequestMiddleware(app);
-})
+/** place this as the last middleware */
++expressOasGenerator.injectRequestMiddleware(app);
+
+app.listen(PORT);
 ```
 
 mind the order of the middleware handlers - first we apply the one for **responses**, then we apply the one for **requests**,

--- a/index.js
+++ b/index.js
@@ -156,54 +156,169 @@ function updateSchemesAndHost(req) {
   }
 }
 
-module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval, aApiDocsPath = 'api-docs') => {
-  app = aApp;
-  predefinedSpec = aPredefinedSpec;
-  const writeInterval = aWriteInterval || 10 * 1000;
+/** TODO - type defs for Express don't work (I tried @external) */
+/**
+ * Apply this **first**!
+ *
+ * (straight after creating the express app (as the very first middleware))
+ *
+ * @description `response` middleware.
+ *
+ * @param {Express} expressApp - the express app
+ *
+ * @param {Object} [options] optional configuration options
+ * @param {string|undefined} [options.pathToOutputFile=undefined] where to write the openAPI specification to.
+ * Specify this to create the openAPI specification file.
+ * @param {number} [options.writeIntervalMs=10000] how often to write the openAPI specification to file
+ *
+ * @returns void
+ */
+function injectResponseMiddleware(expressApp, options = { pathToOutputFile: undefined, writeIntervalMs: 1000 * 10 }) {
+  /**
+   * save the `expressApp` to our local `app` variable.
+   * Used here, but not in `injestRequestMiddleware`,
+   * because this comes before it.
+   */
+  app = expressApp;
 
-  // middleware to handle responses
+  const { pathToOutputFile, writeIntervalMs } = options;
+
+  /** middleware to handle RESPONSES */
+  // eslint-disable-next-line complexity
   app.use((req, res, next) => {
     try {
       const methodAndPathKey = getMethod(req);
+
       if (methodAndPathKey && methodAndPathKey.method) {
         processors.processResponse(res, methodAndPathKey.method);
       }
-      let firstTime = true;
+
+      let firstTime = true; /** run instantly the first time. TODO do not set set `lastRecordTime` at the start until we run */
       const ts = new Date().getTime();
-      if (firstTime || aPath && ts - lastRecordTime > writeInterval) {
+
+      if (firstTime || pathToOutputFile && ts - lastRecordTime > writeIntervalMs) {
         firstTime = false;
         lastRecordTime = ts;
-        fs.writeFile(aPath, JSON.stringify(spec, null, 2), 'utf8', err => {
-          const fullPath = path.resolve(aPath);
+
+        fs.writeFile(pathToOutputFile, JSON.stringify(spec, null, 2), 'utf8', err => {
+          const fullPath = path.resolve(pathToOutputFile);
+
           if (err) {
             throw new Error(`Cannot store the specification into ${fullPath} because of ${err.message}`);
           }
         });
       }
-    } catch (e) {}
-    next();
-  });
-
-  // make sure we list routes after they are configured
-  setTimeout(() => {
-    // middleware to handle requests
-    app.use((req, res, next) => {
-      try {
-        const methodAndPathKey = getMethod(req);
-        if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
-          const method = methodAndPathKey.method;
-          updateSchemesAndHost(req);
-          processors.processPath(req, method, methodAndPathKey.pathKey);
-          processors.processHeaders(req, method, spec);
-          processors.processBody(req, method);
-          processors.processQuery(req, method);
-        }
-      } catch (e) {}
+    } catch (e) {
+      /** TODO - shouldn't we do something here? */
+    } finally {
+      /** always call the next middleware */
       next();
-    });
+    }
+  });
+}
+
+module.exports.injectResponseMiddleware = injectResponseMiddleware;
+
+/** TODO - type defs for Express don't work (I tried @external) */
+/**
+ * Apply this **last**!
+ *
+ * (as the very last middleware of your express app)
+ *
+ * @description `request` middleware.
+ * Applies to the `app` you provided in `injectResponseMiddleware`
+ *
+ * @returns void
+ */
+function injectRequestMiddleware() {
+  /** middleware to handle REQUESTS */
+  // eslint-disable-next-line complexity
+  app.use((req, res, next) => {
+    try {
+      const methodAndPathKey = getMethod(req);
+      if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
+        const method = methodAndPathKey.method;
+        updateSchemesAndHost(req);
+        processors.processPath(req, method, methodAndPathKey.pathKey);
+        processors.processHeaders(req, method, spec);
+        processors.processBody(req, method);
+        processors.processQuery(req, method);
+      }
+    } catch (e) {
+      /** TODO - shouldn't we do something here? */
+    } finally {
+      next();
+    }
+  });
+}
+
+module.exports.injectRequestMiddleware = injectRequestMiddleware;
+
+/**
+ * TODO
+ *
+ * 1. Rename the parameter names
+ * (this will require better global variable naming to allow re-assigning properly)
+ *
+ * 2. the `aPath` is ignored only if it's `undefined`,
+ * but if it's set to an empty string `''`, then the tests fail.
+ * I think we should be checking for falsy values, not only `undefined` ones.
+ *
+ * 3. (Breaking) Use object for optional parameters:
+ * https://github.com/mpashkovskiy/express-oas-generator/issues/35
+ *
+ */
+/**
+ * @warn it's preferred that you use `injectResponseMiddleware`,
+ * `injectRequestMiddleware` and `serveApiDocs` **individually**
+ * and not directly from this `init` function,
+ * because we need `injectRequestMiddleware` to be placed as the
+ * very last middleware and we cannot guarantee this here,
+ * since we're only using an arbitrary setTimeout of `1000` ms.
+ *
+ * See
+ * https://github.com/mpashkovskiy/express-oas-generator/pull/32#issuecomment-546807216
+ *
+ * @description initialize the `express-oas-generator`.
+ *
+ * This will apply both `injectResponseMiddleware` and `injectRequestMiddleware`
+ * and also will call `serveApiDocs`.
+ *
+ * @param {Express} aApp - the express app
+ * @param {*} [aPredefinedSpec=undefined]
+ * @param {string|undefined} [aPath=undefined] where to write the openAPI specification to.
+ * Specify this to create the openAPI specification file.
+ * @param {number} [aWriteInterval=10000] how often to write the openAPI specification to file
+ * @param {string} [aApiDocsPath=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
+ */
+function init(aApp, aPredefinedSpec = undefined, aPath = undefined, aWriteInterval = 1000 * 10, aApiDocsPath = 'api-docs') {
+  /**
+   * TODO - shouldn't `predefinedSpec` be assigned @ `serveApiDocs`?
+   *
+   * I don't know if the `predefinedSpec` is used anywhere for `injectResponseMiddleware`
+   * and before `injectRequestMiddleware` is called
+   */
+  predefinedSpec = aPredefinedSpec;
+
+  injectResponseMiddleware(aApp, { pathToOutputFile: aPath, writeIntervalMs: aWriteInterval });
+
+  /**
+   * make sure we list routes after they are configured
+   *
+   * TODO - this (setTimeout) is error-prone.
+   * See https://github.com/mpashkovskiy/express-oas-generator/pull/32#issuecomment-546807216
+   *
+   * There could be some heavylifing initialization that takes
+   * more than a second and in those cases the requests processing middleware
+   * wouldn't be the last one.
+   */
+  setTimeout(() => {
+    injectRequestMiddleware();
     serveApiDocs({ path: aApiDocsPath, predefinedSpec });
   }, 1000);
-};
+}
+
+module.exports.init = init;
 
 module.exports.getSpec = () => {
   return patchSpec(predefinedSpec);

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ function updateSchemesAndHost(req) {
  *
  * (straight after creating the express app (as the very first middleware))
  *
- * @description `response` middleware.
+ * @description apply the `response` middleware.
  *
  * @param {Express} expressApp - the express app
  *
@@ -193,7 +193,7 @@ function updateSchemesAndHost(req) {
  *
  * @returns void
  */
-function injectResponseMiddleware(expressApp, options = { pathToOutputFile: undefined, writeIntervalMs: 1000 * 10 }) {
+function handleResponses(expressApp, options = { pathToOutputFile: undefined, writeIntervalMs: 1000 * 10 }) {
   responseMiddlewareHasBeenApplied = true;
 
   /**
@@ -250,7 +250,7 @@ function injectResponseMiddleware(expressApp, options = { pathToOutputFile: unde
  * (as the very last middleware of your express app)
  *
  * @description `request` middleware.
- * Applies to the `app` you provided in `injectResponseMiddleware`
+ * Applies to the `app` you provided in `handleResponses`
  *
  * Also, since this is the last function you'll need to invoke,
  * it also initializes the specification and serves the api documentation.
@@ -327,7 +327,7 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
  *
  */
 /**
- * @warn it's preferred that you use `injectResponseMiddleware`,
+ * @warn it's preferred that you use `handleResponses`,
  * `injectRequestMiddleware` and `serveApiDocs` **individually**
  * and not directly from this `init` function,
  * because we need `injectRequestMiddleware` to be placed as the
@@ -339,7 +339,7 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
  *
  * @description initialize the `express-oas-generator`.
  *
- * This will apply both `injectResponseMiddleware` and `injectRequestMiddleware`
+ * This will apply both `handleResponses` and `injectRequestMiddleware`
  * and also will call `serveApiDocs`.
  *
  * @param {Express} aApp - the express app
@@ -353,12 +353,12 @@ function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 10
   /**
    * TODO - shouldn't `predefinedSpec` be assigned @ `serveApiDocs`?
    *
-   * I don't know if the `predefinedSpec` is used anywhere for `injectResponseMiddleware`
+   * I don't know if the `predefinedSpec` is used anywhere for `handleResponses`
    * and before `injectRequestMiddleware` is called
    */
   predefinedSpec = aPredefinedSpec;
 
-  injectResponseMiddleware(aApp, { pathToOutputFile: aPath, writeIntervalMs: aWriteInterval });
+  handleResponses(aApp, { pathToOutputFile: aPath, writeIntervalMs: aWriteInterval });
 
   /**
    * make sure we list routes after they are configured
@@ -384,7 +384,7 @@ const setPackageInfoPath = pkgInfoPath => {
 };
 
 module.exports = {
-  injectResponseMiddleware,
+  handleResponses,
   injectRequestMiddleware,
   init,
   getSpec,

--- a/index.js
+++ b/index.js
@@ -100,8 +100,6 @@ function serveApiDocs(options = { path: 'api-docs', predefinedSpec: undefined })
   });
 }
 
-module.exports.serveApiDocs = serveApiDocs;
-
 function patchSpec(predefinedSpec) {
   return typeof predefinedSpec === 'object'
     ? utils.sortObject(_.merge(spec, predefinedSpec || {}))
@@ -217,8 +215,6 @@ function injectResponseMiddleware(expressApp, options = { pathToOutputFile: unde
   });
 }
 
-module.exports.injectResponseMiddleware = injectResponseMiddleware;
-
 /** TODO - type defs for Express don't work (I tried @external) */
 /**
  * Apply this **last**!
@@ -251,8 +247,6 @@ function injectRequestMiddleware() {
     }
   });
 }
-
-module.exports.injectRequestMiddleware = injectRequestMiddleware;
 
 /**
  * TODO
@@ -318,12 +312,19 @@ function init(aApp, aPredefinedSpec = undefined, aPath = undefined, aWriteInterv
   }, 1000);
 }
 
-module.exports.init = init;
-
-module.exports.getSpec = () => {
+const getSpec = () => {
   return patchSpec(predefinedSpec);
 };
 
-module.exports.setPackageInfoPath = pkgInfoPath => {
+const setPackageInfoPath = pkgInfoPath => {
   packageJsonPath = `${process.cwd()}/${pkgInfoPath}/package.json`;
+};
+
+module.exports = {
+  injectResponseMiddleware,
+  injectRequestMiddleware,
+  serveApiDocs,
+  init,
+  getSpec,
+  setPackageInfoPath
 };

--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ function serveApiDocs(options = { path: 'api-docs', predefinedSpec: {} }) {
 
 function patchSpec(predefinedSpec) {
   return !predefinedSpec
-    ? {}
+    ? spec
     : typeof predefinedSpec === 'object'
       ? utils.sortObject(_.merge(spec, predefinedSpec || {}))
       : predefinedSpec(spec);

--- a/index.js
+++ b/index.js
@@ -43,7 +43,19 @@ function updateSpecFromPackage() {
 
 }
 
-function init(aApiDocsPath) {
+/**
+ * @description serve the openAPI docs with swagger at a specified path / url
+ *
+ * @param {object} options
+ * @param {string} [options.path=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
+ * @param {*} [options.predefinedSpec=undefined]
+ *
+ * @returns void
+ */
+function serveApiDocs(options = { path: 'api-docs', predefinedSpec: undefined }) {
+  const { path, predefinedSpec } = options;
+
+  const aApiDocsPath = path;
   spec = { swagger: '2.0', paths: {} };
 
   const endpoints = listEndpoints(app);
@@ -87,6 +99,8 @@ function init(aApiDocsPath) {
     swaggerUi.setup(patchSpec(predefinedSpec))(req, res);
   });
 }
+
+module.exports.serveApiDocs = serveApiDocs;
 
 function patchSpec(predefinedSpec) {
   return typeof predefinedSpec === 'object'
@@ -187,7 +201,7 @@ module.exports.init = (aApp, aPredefinedSpec, aPath, aWriteInterval, aApiDocsPat
       } catch (e) {}
       next();
     });
-    init(aApiDocsPath);
+    serveApiDocs({ path: aApiDocsPath, predefinedSpec });
   }, 1000);
 };
 

--- a/index.js
+++ b/index.js
@@ -219,6 +219,10 @@ function injectResponseMiddleware(expressApp, options = { pathToOutputFile: unde
           const fullPath = path.resolve(pathToOutputFile);
 
           if (err) {
+            /**
+			 * TODO - this is broken - the error will be caught and ignored in the catch below.
+			 * See https://github.com/mpashkovskiy/express-oas-generator/pull/39#discussion_r340026645
+			 */
             throw new Error(`Cannot store the specification into ${fullPath} because of ${err.message}`);
           }
         });

--- a/index.js
+++ b/index.js
@@ -121,9 +121,11 @@ function serveApiDocs(options = { path: 'api-docs', predefinedSpec: {} }) {
 }
 
 function patchSpec(predefinedSpec) {
-  return typeof predefinedSpec === 'object'
-    ? utils.sortObject(_.merge(spec, predefinedSpec || {}))
-    : predefinedSpec(spec);
+  return !predefinedSpec
+    ? {}
+    : typeof predefinedSpec === 'object'
+      ? utils.sortObject(_.merge(spec, predefinedSpec || {}))
+      : predefinedSpec(spec);
 }
 
 function getPathKey(req) {

--- a/index.js
+++ b/index.js
@@ -368,7 +368,6 @@ const setPackageInfoPath = pkgInfoPath => {
 module.exports = {
   injectResponseMiddleware,
   injectRequestMiddleware,
-  serveApiDocs,
   init,
   getSpec,
   setPackageInfoPath

--- a/index.js
+++ b/index.js
@@ -198,7 +198,7 @@ function handleResponses(expressApp, options = { pathToOutputFile: undefined, wr
 
   /**
    * save the `expressApp` to our local `app` variable.
-   * Used here, but not in `injestRequestMiddleware`,
+   * Used here, but not in `handleRequests`,
    * because this comes before it.
    */
   app = expressApp;
@@ -366,7 +366,7 @@ function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 10
    * TODO - this (setTimeout) is error-prone.
    * See https://github.com/mpashkovskiy/express-oas-generator/pull/32#issuecomment-546807216
    *
-   * There could be some heavylifing initialization that takes
+   * There could be some heavy-lifting initialization that takes
    * more than a second and in those cases the requests processing middleware
    * wouldn't be the last one.
    */

--- a/index.js
+++ b/index.js
@@ -250,9 +250,18 @@ function injectResponseMiddleware(expressApp, options = { pathToOutputFile: unde
  * @description `request` middleware.
  * Applies to the `app` you provided in `injectResponseMiddleware`
  *
+ * Also, since this is the last function you'll need to invoke,
+ * it also initializes the specification and serves the api documentation.
+ * The options are for these tasks.
+ *
+ * @param {object} options
+ * @param {string} [options.path=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
+ * @param {*} [options.predefinedSpec=undefined]
+ *
+ *
  * @returns void
  */
-function injectRequestMiddleware() {
+function injectRequestMiddleware(options = { path: 'api-docs', predefinedSpec: undefined }) {
   /** make sure the middleware placement order (by the user) is correct */
   if (responseMiddlewareHasBeenApplied !== true) {
     const wrongMiddlewareOrderError = `
@@ -296,6 +305,9 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
       next();
     }
   });
+
+  /** forward options to `serveApiDocs`: */
+  serveApiDocs({path: options.path, predefinedSpec: options.predefinedSpec });
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -68,11 +68,11 @@ function updateSpecFromPackage() {
  *
  * @param {object} options
  * @param {string} [options.path=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
- * @param {*} [options.predefinedSpec=undefined]
+ * @param {*} [options.predefinedSpec={}]
  *
  * @returns void
  */
-function serveApiDocs(options = { path: 'api-docs', predefinedSpec: undefined }) {
+function serveApiDocs(options = { path: 'api-docs', predefinedSpec: {} }) {
   const { path, predefinedSpec } = options;
 
   const aApiDocsPath = path;
@@ -256,12 +256,12 @@ function injectResponseMiddleware(expressApp, options = { pathToOutputFile: unde
  *
  * @param {object} options
  * @param {string} [options.path=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
- * @param {*} [options.predefinedSpec=undefined]
+ * @param {*} [options.predefinedSpec={}]
  *
  *
  * @returns void
  */
-function injectRequestMiddleware(options = { path: 'api-docs', predefinedSpec: undefined }) {
+function injectRequestMiddleware(options = { path: 'api-docs', predefinedSpec: {} }) {
   /** make sure the middleware placement order (by the user) is correct */
   if (responseMiddlewareHasBeenApplied !== true) {
     const wrongMiddlewareOrderError = `
@@ -341,13 +341,13 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
  * and also will call `serveApiDocs`.
  *
  * @param {Express} aApp - the express app
- * @param {*} [aPredefinedSpec=undefined]
+ * @param {*} [aPredefinedSpec={}]
  * @param {string|undefined} [aPath=undefined] where to write the openAPI specification to.
  * Specify this to create the openAPI specification file.
  * @param {number} [aWriteInterval=10000] how often to write the openAPI specification to file
  * @param {string} [aApiDocsPath=api-docs] where to serve the openAPI docs. Defaults to `api-docs`
  */
-function init(aApp, aPredefinedSpec = undefined, aPath = undefined, aWriteInterval = 1000 * 10, aApiDocsPath = 'api-docs') {
+function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 1000 * 10, aApiDocsPath = 'api-docs') {
   /**
    * TODO - shouldn't `predefinedSpec` be assigned @ `serveApiDocs`?
    *

--- a/index.js
+++ b/index.js
@@ -9,6 +9,11 @@ const listEndpoints = require('express-list-endpoints');
 let packageJsonPath = `${process.cwd()}/package.json`;
 let packageInfo;
 let app;
+
+/**
+ * @param {function|object} predefinedSpec either the Swagger specification
+ * or a function with one argument producing it.
+ */
 let predefinedSpec;
 let spec = {};
 let lastRecordTime = new Date().getTime();

--- a/index.js
+++ b/index.js
@@ -249,7 +249,7 @@ function handleResponses(expressApp, options = { pathToOutputFile: undefined, wr
  *
  * (as the very last middleware of your express app)
  *
- * @description `request` middleware.
+ * @description apply the `request` middleware
  * Applies to the `app` you provided in `handleResponses`
  *
  * Also, since this is the last function you'll need to invoke,
@@ -263,7 +263,7 @@ function handleResponses(expressApp, options = { pathToOutputFile: undefined, wr
  *
  * @returns void
  */
-function injectRequestMiddleware(options = { path: 'api-docs', predefinedSpec: {} }) {
+function handleRequests(options = { path: 'api-docs', predefinedSpec: {} }) {
   /** make sure the middleware placement order (by the user) is correct */
   if (responseMiddlewareHasBeenApplied !== true) {
     const wrongMiddlewareOrderError = `
@@ -328,9 +328,9 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
  */
 /**
  * @warn it's preferred that you use `handleResponses`,
- * `injectRequestMiddleware` and `serveApiDocs` **individually**
+ * `handleRequests` and `serveApiDocs` **individually**
  * and not directly from this `init` function,
- * because we need `injectRequestMiddleware` to be placed as the
+ * because we need `handleRequests` to be placed as the
  * very last middleware and we cannot guarantee this here,
  * since we're only using an arbitrary setTimeout of `1000` ms.
  *
@@ -339,7 +339,7 @@ For more information, see https://github.com/mpashkovskiy/express-oas-generator#
  *
  * @description initialize the `express-oas-generator`.
  *
- * This will apply both `handleResponses` and `injectRequestMiddleware`
+ * This will apply both `handleResponses` and `handleRequests`
  * and also will call `serveApiDocs`.
  *
  * @param {Express} aApp - the express app
@@ -354,7 +354,7 @@ function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 10
    * TODO - shouldn't `predefinedSpec` be assigned @ `serveApiDocs`?
    *
    * I don't know if the `predefinedSpec` is used anywhere for `handleResponses`
-   * and before `injectRequestMiddleware` is called
+   * and before `handleRequests` is called
    */
   predefinedSpec = aPredefinedSpec;
 
@@ -371,7 +371,7 @@ function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 10
    * wouldn't be the last one.
    */
   setTimeout(() => {
-    injectRequestMiddleware({ path: aApiDocsPath, predefinedSpec });
+    handleRequests({ path: aApiDocsPath, predefinedSpec });
   }, 1000);
 }
 
@@ -385,7 +385,7 @@ const setPackageInfoPath = pkgInfoPath => {
 
 module.exports = {
   handleResponses,
-  injectRequestMiddleware,
+  handleRequests,
   init,
   getSpec,
   setPackageInfoPath

--- a/index.js
+++ b/index.js
@@ -371,8 +371,7 @@ function init(aApp, aPredefinedSpec = {}, aPath = undefined, aWriteInterval = 10
    * wouldn't be the last one.
    */
   setTimeout(() => {
-    injectRequestMiddleware();
-    serveApiDocs({ path: aApiDocsPath, predefinedSpec });
+    injectRequestMiddleware({ path: aApiDocsPath, predefinedSpec });
   }, 1000);
 }
 

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -308,7 +308,7 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
 
   expect(() => {
     try {
-      generator.injectResponseMiddleware(app, {});
+      generator.handleResponses(app, {});
       generator.injectRequestMiddleware(app);
     } catch (err) {
       /**

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -289,15 +289,13 @@ it('WHEN no custom path for docs set THEN the default path should be provided', 
 });
 
 it('WHEN **request** middleware is injected before **response** middleware THEN an error should be thrown', done => {
-  const app = express();
-
   /**
    * @note make sure that the global variables are reset
    * after every test
    */
 
   expect(() => {
-    generator.handleRequests(app);
+    generator.handleRequests();
   }).toThrowError();
 
   done();
@@ -309,7 +307,7 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
   expect(() => {
     try {
       generator.handleResponses(app, {});
-      generator.handleRequests(app);
+      generator.handleRequests();
     } catch (err) {
       /**
 	   * this shoud NOT happen, but if it does - log the error & let it bubble

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -307,8 +307,18 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
   const app = express();
 
   expect(() => {
-    generator.injectResponseMiddleware(app, {});
-    generator.injectRequestMiddleware(app);
+    try {
+      generator.injectResponseMiddleware(app, {});
+      generator.injectRequestMiddleware(app);
+    } catch (err) {
+      /**
+	   * this shoud NOT happen, but if it does - log the error & let it bubble
+	   */
+
+      // eslint-disable-next-line no-console
+      console.error(err);
+      throw err;
+    }
   }).not.toThrowError();
 
   done();

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -287,3 +287,29 @@ it('WHEN no custom path for docs set THEN the default path should be provided', 
     }, MS_TO_STARTUP);
   });
 });
+
+it('WHEN **request** middleware is injected before **response** middleware THEN an error should be thrown', done => {
+  const app = express();
+
+  /**
+   * @note make sure that the global variables are reset
+   * after every test
+   */
+
+  expect(() => {
+    generator.injectRequestMiddleware(app);
+  }).toThrowError();
+
+  done();
+});
+
+it('WHEN middleware order is correct THEN no errors should be thrown', done => {
+  const app = express();
+
+  expect(() => {
+    generator.injectResponseMiddleware(app, {});
+    generator.injectRequestMiddleware(app);
+  }).not.toThrowError();
+
+  done();
+});

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -310,7 +310,7 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
       generator.handleRequests();
     } catch (err) {
       /**
-	   * this shoud NOT happen, but if it does - log the error & let it bubble
+	   * this should NOT happen, but if it does - log the error & let it bubble
 	   */
 
       // eslint-disable-next-line no-console

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -297,7 +297,7 @@ it('WHEN **request** middleware is injected before **response** middleware THEN 
    */
 
   expect(() => {
-    generator.injectRequestMiddleware(app);
+    generator.handleRequests(app);
   }).toThrowError();
 
   done();
@@ -309,7 +309,7 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
   expect(() => {
     try {
       generator.handleResponses(app, {});
-      generator.injectRequestMiddleware(app);
+      generator.handleRequests(app);
     } catch (err) {
       /**
 	   * this shoud NOT happen, but if it does - log the error & let it bubble


### PR DESCRIPTION
I have:
* renamed the local `init` function into `serveApiDocs` for clarity
* extracted the response/request handling middleware into separate functions
	* used them in the main `init` method for backwards-compatibility
	* exported them for power-users to use individually
* documented the function parameters with jsdoc
* ran tests to make sure everything still works fine.

This is NOT a breaking change.

Before merging, I'd like to:

* [x] solve most of relevant `TODO` marked comments.
* [x] consider shorter names for the new functions, like `handleResponses` and `handleRequests`
* [x] provide proper type definitions for fields that don't yet have them, like `predefinedSpec`.
	* [x] ~~The express type definitions are external and I couldn't make them work atm.~~ WONTFIX, maybe typescript in the future
* [x] write tests for individual functions?
	* [ ] also tests for the whole process, since individuals functions are always used now.
* [x] once we're done with the code, update the documentation.

I need feedback!:D

---

See also #32. This PR removes the need for it, but in the case where the user still uses the older method (often), we still have the same error-prone solution:

https://github.com/mpashkovskiy/express-oas-generator/pull/32#issuecomment-546807216
> Indeed there could be some heavylifing initialization that takes more than a second and in those cases requests processing middleware wouldn't be the last one.

I'd be good to at least document that we're doing this in the README (I've written notes @ the `init` function already)