### PR TITLE
Add description property to Responses

### DIFF
--- a/lib/processors.js
+++ b/lib/processors.js
@@ -180,6 +180,7 @@ function updateResponses(res, method, chunks) {
       example: type === 'string' ? body : Number(body)
     };
   }
+  method.responses[res.statusCode].description = utils.getResponseDescription(res.statusCode);
   method.responses[res.statusCode].schema = schema;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -74,3 +74,78 @@ module.exports.getSchema = json => {
   fillExamples(schema, json);
   return schema;
 };
+
+/**
+ *
+ * @param responseCode
+ * @returns {string}
+ */
+module.exports.getResponseDescription = responseCode => {
+  const responseDescriptionMapping = {
+    '100': 'Continue',
+    '101': 'Switching Protocols',
+    '102': 'Processing',
+    '200': 'OK',
+    '201': 'Created',
+    '202': 'Accepted',
+    '203': 'Non-authoritative Information',
+    '204': 'No Content',
+    '205': 'Reset Content',
+    '206': 'Partial Content',
+    '207': 'Multi-Status',
+    '208': 'Already Reported',
+    '226': 'IM Used',
+    '300': 'Multiple Choices',
+    '301': 'Moved Permanently',
+    '302': 'Found',
+    '303': 'See Other',
+    '304': 'Not Modified',
+    '305': 'Use Proxy',
+    '307': 'Temporary Redirect',
+    '308': 'Permanent Redirect',
+    '400': 'Bad Request',
+    '401': 'Unauthorized',
+    '402': 'Payment Required',
+    '403': 'Forbidden',
+    '404': 'Not Found',
+    '405': 'Method Not Allowed',
+    '406': 'Not Acceptable',
+    '407': 'Proxy Authentication Required',
+    '408': 'Request Timeout',
+    '409': 'Conflict',
+    '410': 'Gone',
+    '411': 'Length Required',
+    '412': 'Precondition Failed',
+    '413': 'Payload Too Large',
+    '414': 'Request-URI Too Long',
+    '415': 'Unsupported Media Type',
+    '416': 'Requested Range Not Satisfiable',
+    '417': 'Expectation Failed',
+    '418': 'I\'m a teapot',
+    '421': 'Misdirected Request',
+    '422': 'Unprocessable Entity',
+    '423': 'Locked',
+    '424': 'Failed Dependency',
+    '426': 'Upgrade Required',
+    '428': 'Precondition Required',
+    '429': 'Too Many Requests',
+    '431': 'Request Header Fields Too Large',
+    '444': 'Connection Closed Without Response',
+    '451': 'Unavailable For Legal Reasons',
+    '499': 'Client Closed Request',
+    '500': 'Internal Server Error',
+    '501': 'Not Implemented',
+    '502': 'Bad Gateway',
+    '503': 'Service Unavailable',
+    '504': 'Gateway Timeout',
+    '505': 'HTTP Version Not Supported',
+    '506': 'Variant Also Negotiates',
+    '507': 'Insufficient Storage',
+    '508': 'Loop Detected',
+    '510': 'Not Extended',
+    '511': 'Network Authentication Required',
+    '599': 'Network Connect Timeout Error'
+  };
+  return responseDescriptionMapping[responseCode];
+};
+

--- a/test/lib/processors_tests.js
+++ b/test/lib/processors_tests.js
@@ -127,6 +127,7 @@ describe('processors.js', () => {
       expect(method.produces).toEqual([appJson]);
       expect(Object.keys(method.responses)).toEqual(['200']);
       expect(method.responses['200'].schema).not.toBe(undefined);
+      expect(method.responses['200'].description).toBe('OK');
     });
 
   });

--- a/test/lib/util_tests.js
+++ b/test/lib/util_tests.js
@@ -44,4 +44,9 @@ describe('utils.js', () => {
     expect(schema.properties.inner0.properties.a.example).toEqual([1]);
   });
 
+  it('WHEN getResponseDescription method called THEN it returns corresponding description of the response code', () => {
+    const responseDescription = utils.getResponseDescription(100);
+    expect(responseDescription).toBe('Continue');
+  });
+
 });


### PR DESCRIPTION
The Responses object for every status code currently holds only the "schema" property being auto-generated. But the "description" property is also considered as [required property](https://swagger.io/docs/specification/describing-responses/#ctxM:~:text=Each%20response%20status%20requires%20a%20description.)  as per open-api specification.

![image](https://user-images.githubusercontent.com/34732740/86264384-105fbe80-bbe0-11ea-973d-7ced5cfd9502.png)

Please review.