### PR TITLE
Feature/#46 mongoose model definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,14 @@ expressOasGenerator.init(
   app,
   function(spec) { return spec; },
   'path/to/a/file/filename.json',
-  60 * 1000
+  60 * 1000,
+  ['User','Student']
 )
 ```
 where:
 * 'path/to/a/file/filename.json' - path to a file and file name
 * 60 * 1000 - write interval in milliseconds (optional parameter, by default interval is equal to 10 seconds)
+* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames()
 
 To change the Swagger UI path for your REST API use fifth (optional) argument:
 ```javascript
@@ -69,13 +71,15 @@ expressOasGenerator.init(
   function(spec) { return spec; },
   'path/to/a/file/filename.json',
   60 * 1000,
-  'custom-docs-path'
+  'custom-docs-path',
+  ['User','Student']
 )
 ```
 where:
 * 'path/to/a/file/filename.json' - path to a file and file name
 * 60 * 1000 - write interval in milliseconds (optional parameter, by default interval is equal to 10 seconds)
 * 'custom-docs-path' - Swagger UI path for your REST API (default: api-docs)
+* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames()
 
 ## Advanced usage (recommended)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ expressOasGenerator.init(
 where:
 * 'path/to/a/file/filename.json' - path to a file and file name
 * 60 * 1000 - write interval in milliseconds (optional parameter, by default interval is equal to 10 seconds)
-* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames()
+* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames().
+The following peer dependencies are required to use this last argument: mongoose, mongoose-to-swagger, bson.
 
 To change the Swagger UI path for your REST API use fifth (optional) argument:
 ```javascript
@@ -79,7 +80,8 @@ where:
 * 'path/to/a/file/filename.json' - path to a file and file name
 * 60 * 1000 - write interval in milliseconds (optional parameter, by default interval is equal to 10 seconds)
 * 'custom-docs-path' - Swagger UI path for your REST API (default: api-docs)
-* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames()
+* ['User','Student'] - Mongoose models to be included as definitions. To get all just do mongoose.modelNames().
+The following peer dependencies are required to this last argument: mongoose, mongoose-to-swagger, bson.
 
 ## Advanced usage (recommended)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,6 +32,9 @@ export interface HandleResponsesOptions {
 
 	/** how often to write the openAPI specification to file */
 	writeIntervalMs?: number;
+
+	/** Mongoose model names */
+	mongooseModels?: Array<string>;
 }
 
 /**
@@ -78,7 +81,8 @@ export function init(
 	predefinedSpec?: HandleResponsesOptions['predefinedSpec'],
 	specOutputPath?: HandleResponsesOptions['specOutputPath'],
 	writeIntervalMs?: HandleResponsesOptions['writeIntervalMs'],
-	swaggerUiServePath?: HandleResponsesOptions['swaggerUiServePath']
+	swaggerUiServePath?: HandleResponsesOptions['swaggerUiServePath'],
+	mongooseModels?: HandleResponsesOptions['mongooseModels']
 ): void;
 
 export const getSpec: () => object | OpenAPIV2.Document;

--- a/index.js
+++ b/index.js
@@ -132,10 +132,7 @@ function serveApiDocs() {
     });
   });
 
-  if (mongooseModelsSpecs) {
-    spec.definitions = mongooseModelsSpecs;
-  }
-
+  spec.definitions = mongooseModelsSpecs || {};
   updateSpecFromPackage();
   spec = patchSpec(predefinedSpec);
   app.use(packageInfo.baseUrlPath + '/api-spec', (req, res, next) => {

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ function updateSchemesAndHost(req) {
 /**
  * @description Generates definitions spec from mongoose models
  *
- * @returns string
+ * @returns Definitions spec
  */
 function updateDefinitionsSpec(mongooseModels) {
   const validMongooseModels = Array.isArray(mongooseModels) && mongooseModels.length > 0;

--- a/index.js
+++ b/index.js
@@ -223,10 +223,25 @@ function updateSchemesAndHost(req) {
     spec.host = req.get('host');
   }
 }
+
+/**
+ * @description Generates definitions spec from mongoose models
+ *
+ * @returns string
+ */
+function updateDefinitionsSpec(mongooseModels) {
+  const validMongooseModels = Array.isArray(mongooseModels) && mongooseModels.length > 0;
+  
+  if (validMongooseModels && !mongooseModelsSpecs) {
+    mongooseModelsSpecs = generateMongooseModelsSpec(mongooseModels);
+  }
+  return mongooseModelsSpecs;
+}
+
 /**
  * @type { typeof import('./index').handleResponses }
 */
-function handleResponses(expressApp, options = { swaggerUiServePath: 'api-docs', specOutputPath: undefined, predefinedSpec: {}, writeIntervalMs: 1000 * 10 }) {
+function handleResponses(expressApp, options = { swaggerUiServePath: 'api-docs', specOutputPath: undefined, predefinedSpec: {}, writeIntervalMs: 1000 * 10, mongooseModels: []}) {
   responseMiddlewareHasBeenApplied = true;
 
   /**
@@ -238,6 +253,8 @@ function handleResponses(expressApp, options = { swaggerUiServePath: 'api-docs',
   swaggerUiServePath = options.swaggerUiServePath || 'api-docs';
   predefinedSpec = options.predefinedSpec || {};
   const { specOutputPath, writeIntervalMs } = options;
+
+  updateDefinitionsSpec(options.mongooseModels);
 
   /** middleware to handle RESPONSES */
   app.use((req, res, next) => {
@@ -336,9 +353,7 @@ function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInt
     handleRequests();
   }, 1000);
   
-  if (mongooseModels && Array.isArray(mongooseModels) && mongooseModels.length > 0) {
-    mongooseModelsSpecs = generateMongooseModelsSpec(mongooseModels);
-  }
+  updateDefinitionsSpec(mongooseModels);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -232,7 +232,6 @@ function updateDefinitionsSpec(mongooseModels) {
   if (validMongooseModels && !mongooseModelsSpecs) {
     mongooseModelsSpecs = generateMongooseModelsSpec(mongooseModels);
   }
-  return mongooseModelsSpecs;
 }
 
 /**

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,22 +1,16 @@
 const m2s = require('mongoose-to-swagger'); 
 
 module.exports.generateMongooseModelsSpec = mongooseModelNames => {
-  try {
-    /* Disabling because its a peer dependency */
-    /* eslint-disable global-require */
-    /* @ts-ignore */
-    const mongoose = require('mongoose');
+  /* Disabling because its a peer dependency */
+  /* eslint-disable global-require */
+  /* @ts-ignore */
+  const mongoose = require('mongoose');
 
-    const mongooseModelSpecs = mongooseModelNames.map(m => m2s(mongoose.model(m)));
-    
-    return mongooseModelSpecs.reduce((parsedMongooseModelSpecs, modelSpec) => {
-      parsedMongooseModelSpecs[modelSpec.title] = modelSpec;
-      return parsedMongooseModelSpecs;
-    }, {});
+  const mongooseModelSpecs = mongooseModelNames.map(m => m2s(mongoose.model(m)));
 
-  
-  } catch (err) {
-    throw new Error(`${err.message}`);
-  }
+  return mongooseModelSpecs.reduce((parsedMongooseModelSpecs, modelSpec) => {
+    parsedMongooseModelSpecs[modelSpec.title] = modelSpec;
+    return parsedMongooseModelSpecs;
+  }, {});
 };
   

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,0 +1,22 @@
+const m2s = require('mongoose-to-swagger'); 
+
+module.exports.generateMongooseModelsSpec = mongooseModelNames => {
+  try {
+    /* Disabling because its a peer dependency */
+    /* eslint-disable global-require */
+    /* @ts-ignore */
+    const mongoose = require('mongoose');
+
+    const mongooseModelSpecs = mongooseModelNames.map(m => m2s(mongoose.model(m)));
+    
+    return mongooseModelSpecs.reduce((parsedMongooseModelSpecs, modelSpec) => {
+      parsedMongooseModelSpecs[modelSpec.title] = modelSpec;
+      return parsedMongooseModelSpecs;
+    }, {});
+
+  
+  } catch (err) {
+    throw new Error(`${err.message}`);
+  }
+};
+  

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,6 +1,6 @@
 /* eslint-disable global-require */
 module.exports.generateMongooseModelsSpec = mongooseModelNames => {
-  /* Disabling because its a peer dependency */
+  /* Both are peer dependencies. They are required at this level. */
   const mongoose = require('mongoose');
   const m2s = require('mongoose-to-swagger'); 
 

--- a/lib/mongoose.js
+++ b/lib/mongoose.js
@@ -1,10 +1,8 @@
-const m2s = require('mongoose-to-swagger'); 
-
+/* eslint-disable global-require */
 module.exports.generateMongooseModelsSpec = mongooseModelNames => {
   /* Disabling because its a peer dependency */
-  /* eslint-disable global-require */
-  /* @ts-ignore */
   const mongoose = require('mongoose');
+  const m2s = require('mongoose-to-swagger'); 
 
   const mongooseModelSpecs = mongooseModelNames.map(m => m2s(mongoose.model(m)));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -381,6 +381,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -388,6 +394,16 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "bl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+      "integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "bluebird": {
@@ -422,6 +438,26 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "bson": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+      "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.1.0",
+        "long": "^4.0.0"
+      }
+    },
+    "buffer": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+      "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4"
       }
     },
     "buffer-from": {
@@ -792,6 +828,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "denque": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
       "dev": true
     },
     "depd": {
@@ -1415,6 +1457,12 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+      "dev": true
+    },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -1781,6 +1829,12 @@
         "verror": "1.10.0"
       }
     },
+    "kareem": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.1.tgz",
+      "integrity": "sha512-l3hLhffs9zqoDe8zjmb/mAN4B8VT3L56EUvKNqLFVs9YlFA+zx7ke1DO8STAdDyYNkeSo1nKmjuvQeI12So8Xw==",
+      "dev": true
+    },
     "klaw": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
@@ -1868,6 +1922,12 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -1924,6 +1984,13 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "dev": true,
+      "optional": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -2011,10 +2078,113 @@
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
     },
+    "mongodb": {
+      "version": "3.5.9",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.9.tgz",
+      "integrity": "sha512-vXHBY1CsGYcEPoVWhwgxIBeWqP3dSu9RuRDsoLRPTITrcrgm1f0Ubu1xqF9ozMwv53agmEiZm0YGo+7WL3Nbug==",
+      "dev": true,
+      "requires": {
+        "bl": "^2.2.0",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+          "dev": true
+        }
+      }
+    },
+    "mongoose": {
+      "version": "5.9.25",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.9.25.tgz",
+      "integrity": "sha512-vz/DqJ3mrHqEIlfRbKmDZ9TzQ1a0hCtSQpjHScIxr4rEtLs0tjsXDeEWcJ/vEEc3oLfP6vRx9V+uYSprXDUvFQ==",
+      "dev": true,
+      "requires": {
+        "bson": "^1.1.4",
+        "kareem": "2.3.1",
+        "mongodb": "3.5.9",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.7.0",
+        "mquery": "3.2.2",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+          "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
+      "dev": true
+    },
     "mongoose-to-swagger": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mongoose-to-swagger/-/mongoose-to-swagger-1.0.3.tgz",
       "integrity": "sha512-XfEXzX9yBP8Dts0fft7olTh1G95KFl0T7NL8NnRovRYDaUyS2jPRVrqvG77lZxCQf3EI+0845morSQ+P+fc+Cg=="
+    },
+    "mpath": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.7.0.tgz",
+      "integrity": "sha512-Aiq04hILxhz1L+f7sjGyn7IxYzWm1zLNNXcfhDtx04kZ2Gk7uvFdgZ8ts1cWa/6d0TQmag2yR8zSGZUmp0tFNg==",
+      "dev": true
+    },
+    "mquery": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.2.tgz",
+      "integrity": "sha512-XB52992COp0KP230I3qloVUbkLUxJIu328HBP2t2EsxSFtf4W1HPSOBWOXf1bqxK4Xbb66lfMJ+Bpfd9/yZE1Q==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -2415,6 +2585,12 @@
         }
       }
     },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
+      "dev": true
+    },
     "regexpp": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
@@ -2486,6 +2662,24 @@
       "requires": {
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
+      }
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        }
       }
     },
     "requizzle": {
@@ -2564,6 +2758,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2638,6 +2842,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -2653,11 +2863,27 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E=",
+      "dev": true
+    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spawn-wrap": {
       "version": "1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2142,7 +2142,8 @@
     "mongoose-to-swagger": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mongoose-to-swagger/-/mongoose-to-swagger-1.0.3.tgz",
-      "integrity": "sha512-XfEXzX9yBP8Dts0fft7olTh1G95KFl0T7NL8NnRovRYDaUyS2jPRVrqvG77lZxCQf3EI+0845morSQ+P+fc+Cg=="
+      "integrity": "sha512-XfEXzX9yBP8Dts0fft7olTh1G95KFl0T7NL8NnRovRYDaUyS2jPRVrqvG77lZxCQf3EI+0845morSQ+P+fc+Cg==",
+      "dev": true
     },
     "mpath": {
       "version": "0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2011,6 +2011,11 @@
       "integrity": "sha1-Rpve9PivyaEWBW8HnfYYLQr7A4Q=",
       "dev": true
     },
+    "mongoose-to-swagger": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose-to-swagger/-/mongoose-to-swagger-1.0.3.tgz",
+      "integrity": "sha512-XfEXzX9yBP8Dts0fft7olTh1G95KFl0T7NL8NnRovRYDaUyS2jPRVrqvG77lZxCQf3EI+0845morSQ+P+fc+Cg=="
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "body-parser": "^1.18.2",
+    "bson": "^4.0.4",
     "coveralls": "^3.0.0",
     "docdash": "^1.1.1",
     "eslint": "^4.13.1",
@@ -53,6 +54,7 @@
     "jasmine-spec-reporter": "^4.2.1",
     "jsdoc": "^3.6.3",
     "mocha-lcov-reporter": "^1.3.0",
+    "mongoose": "^5.9.25",
     "nyc": "^14.1.1",
     "request": "^2.88.0",
     "zlib": "^1.0.5"

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "nyc": "^14.1.1",
     "request": "^2.88.0",
     "zlib": "^1.0.5"
+  },
+  "peerDependencies": {
+    "mongoose": "^5.9.25"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,10 +36,11 @@
     "@types/express": "^4.17.2",
     "express-list-endpoints": "^3.0.1",
     "generate-schema": "^2.6.0",
+    "lodash.merge": "^4.6.2",
+    "mongoose-to-swagger": "^1.0.3",
     "openapi-types": "^1.3.5",
     "swagger-ui-express": "^3.0.8",
-    "typescript": "^3.7.2",
-    "lodash.merge": "^4.6.2"
+    "typescript": "^3.7.2"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "express-list-endpoints": "^3.0.1",
     "generate-schema": "^2.6.0",
     "lodash.merge": "^4.6.2",
-    "mongoose-to-swagger": "^1.0.3",
     "openapi-types": "^1.3.5",
     "swagger-ui-express": "^3.0.8",
     "typescript": "^3.7.2"
@@ -55,11 +54,14 @@
     "jsdoc": "^3.6.3",
     "mocha-lcov-reporter": "^1.3.0",
     "mongoose": "^5.9.25",
+    "mongoose-to-swagger": "^1.0.3",
     "nyc": "^14.1.1",
     "request": "^2.88.0",
     "zlib": "^1.0.5"
   },
   "peerDependencies": {
-    "mongoose": "^5.9.25"
+    "bson": "^4.0.4",
+    "mongoose": "^5.9.25",
+    "mongoose-to-swagger": "^1.0.3"
   }
 }

--- a/server_advanced.js
+++ b/server_advanced.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Example of using the module
 
 const express = require('express');
@@ -5,6 +6,8 @@ const bodyParser = require('body-parser');
 const generator = require('./index.js');
 const _ = require('lodash');
 const zlib = require('zlib');
+require('./test/lib/mongoose_models/student');
+const mongoose = require('mongoose');
 
 const app = express();
 generator.handleResponses(app, {
@@ -13,33 +16,34 @@ generator.handleResponses(app, {
     return spec;
   },
   specOutputPath: './test_spec.json',
+  mongooseModels: mongoose.modelNames()
 });
 
 app.use(bodyParser.json({}));
 let router = express.Router();
 router.route('/foo/stranger')
-      .get(function(req, res, next) {
-        //code here
-        console.log('calling /foo/stranger');
-        res.json({message: 'hello stranger'});
-        return next();
-      });
+  .get(function(req, res, next) {
+    //code here
+    console.log('calling /foo/stranger');
+    res.json({message: 'hello stranger'});
+    return next();
+  });
 router.route('/foo/:name')
-      .get(function (req, res, next) {
-        console.log('calling /foo/:name');
-        res.json({message: 'hello ' + req.params.name});
-        return next();
-      });
+  .get(function(req, res, next) {
+    console.log('calling /foo/:name');
+    res.json({message: 'hello ' + req.params.name});
+    return next();
+  });
 router.route('/gzip')
-      .get(function(req, res, next) {
-        console.log('calling /gzip');
-        res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Content-Encoding', 'gzip');
-        zlib.gzip(JSON.stringify({message: 'gzip'}), function (error, result) {
-          res.status(200).send(result);
-          return next();
-        });
-      });
+  .get(function(req, res, next) {
+    console.log('calling /gzip');
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Encoding', 'gzip');
+    zlib.gzip(JSON.stringify({message: 'gzip'}), function(error, result) {
+      res.status(200).send(result);
+      return next();
+    });
+  });
 app.use(router);
 app.set('port', 8080);
 generator.handleRequests();

--- a/server_basic.js
+++ b/server_basic.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // Example of using the module
 
 const express = require('express');
@@ -5,43 +6,45 @@ const bodyParser = require('body-parser');
 const generator = require('./index.js');
 const _ = require('lodash');
 const zlib = require('zlib');
+require('./test/lib/mongoose_models/student');
+const mongoose = require('mongoose');
 
 const app = express();
 generator.init(app, function(spec) {
   _.set(spec, 'paths["/foo/{name}"].get.parameters[0].description', 'description of a parameter');
   return spec;
-}, './test_spec.json');
+}, './test_spec.json', 1000, 'api-docs', mongoose.modelNames());
 
 app.use(bodyParser.json({}));
 let router = express.Router();
 router.route('/foo/stranger')
-      .post(function(req, res, next) {
-        //code here
-        console.log('calling /foo/stranger');
-        res.json(req.body);
-        return next();
-      });
+  .post(function(req, res, next) {
+    //code here
+    console.log('calling /foo/stranger');
+    res.json(req.body);
+    return next();
+  });
 router.route('/foo/:name')
-      .get(function(req, res, next) {
-        console.log('calling /foo/:name');
-        var a = Math.random();
-        if (a > 0.5) {
-          res.json({message: 'hello ' + req.params.name});
-        } else {
-          res.json({message: 'hello ' + req.params.name, a: [{b: 1}, {b: 2, c: 'asd'}]});
-        }
-        return next();
-      });
+  .get(function(req, res, next) {
+    console.log('calling /foo/:name');
+    let a = Math.random();
+    if (a > 0.5) {
+      res.json({message: 'hello ' + req.params.name});
+    } else {
+      res.json({message: 'hello ' + req.params.name, a: [{b: 1}, {b: 2, c: 'asd'}]});
+    }
+    return next();
+  });
 router.route('/gzip')
-      .get(function(req, res, next) {
-        console.log('calling /gzip');
-        res.setHeader('Content-Type', 'application/json');
-        res.setHeader('Content-Encoding', 'gzip');
-        zlib.gzip(JSON.stringify({message: 'gzip'}), function (error, result) {
-          res.status(200).send(result);
-          return next();
-        })
-      });
+  .get(function(req, res, next) {
+    console.log('calling /gzip');
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Encoding', 'gzip');
+    zlib.gzip(JSON.stringify({message: 'gzip'}), function(error, result) {
+      res.status(200).send(result);
+      return next();
+    });
+  });
 app.use(router);
 app.set('port', 8080);
 app.listen(app.get('port'), function() {

--- a/test/lib/mongoose_models/student.js
+++ b/test/lib/mongoose_models/student.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const studentSchema = new mongoose.Schema({
+  id: { type: Number, required: true},
+  name: { type: String, required: true},
+});
+
+const studentModel = new mongoose.model('Student', studentSchema);
+
+module.exports = studentModel;

--- a/test/lib/mongoose_tests.js
+++ b/test/lib/mongoose_tests.js
@@ -17,7 +17,7 @@ describe('mongoose.js', () => {
       }
     });
 
-    it('WHEN supplied mongoose model does not exist THEN should throw exception', () => {
+    it('WHEN mongoose model exists THEN it should generate the model spec', () => {
       const mongooseModels = ['Student'];
     
       const mongooseModelSpecs = generateMongooseModelsSpec(mongooseModels);

--- a/test/lib/mongoose_tests.js
+++ b/test/lib/mongoose_tests.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const {generateMongooseModelsSpec} = require('../../lib/mongoose.js');
+require('./mongoose_models/student');
+
+describe('mongoose.js', () => {
+
+  describe('generateMongooseModelsSpec()', () => {
+    it('WHEN supplied mongoose model does not exist THEN should throw exception', () => {
+      const mongooseModels = ['User', 'Student'];
+    
+      try {
+        generateMongooseModelsSpec(mongooseModels);
+        throw new Error();
+      } catch (err) {
+        expect(err.message).toContain(`Schema hasn't been registered for model "${mongooseModels.shift()}"`);
+      }
+    });
+
+    it('WHEN supplied mongoose model does not exist THEN should throw exception', () => {
+      const mongooseModels = ['Student'];
+    
+      const mongooseModelSpecs = generateMongooseModelsSpec(mongooseModels);
+      const studentModelSpec = mongooseModelSpecs[mongooseModels.shift()];
+      /* Not asserting the spec itself, trusting mongoose-to-swagger :) */
+      expect(studentModelSpec).toBeDefined();
+    });
+  });
+});

--- a/test/lib/mongoose_tests.js
+++ b/test/lib/mongoose_tests.js
@@ -10,13 +10,11 @@ describe('mongoose.js', () => {
   describe('generateMongooseModelsSpec()', () => {
     it('WHEN supplied mongoose model does not exist THEN should throw exception', () => {
       const mongooseModels = ['User', 'Student'];
-    
-      try {
-        generateMongooseModelsSpec(mongooseModels);
-        throw new Error();
-      } catch (err) {
-        expect(err.message).toContain(`Schema hasn't been registered for model "${mongooseModels.shift()}"`);
-      }
+      
+      return expect(() => {
+        generateMongooseModelsSpec(mongooseModels); 
+      })
+        .toThrowError(new RegExp(`Schema hasn't been registered for model "${mongooseModels[0]}"`));
     });
 
     it('WHEN mongoose model exists THEN it should generate the model spec', () => {

--- a/test/lib/mongoose_tests.js
+++ b/test/lib/mongoose_tests.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const mongoose = require('mongoose');
-const {generateMongooseModelsSpec} = require('../../lib/mongoose.js');
 require('./mongoose_models/student');
+
+const {generateMongooseModelsSpec} = require('../../lib/mongoose.js');
 
 describe('mongoose.js', () => {
 

--- a/test/lib/mongoose_tests.js
+++ b/test/lib/mongoose_tests.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mongoose = require('mongoose');
 const {generateMongooseModelsSpec} = require('../../lib/mongoose.js');
 require('./mongoose_models/student');
 
@@ -18,12 +19,14 @@ describe('mongoose.js', () => {
     });
 
     it('WHEN mongoose model exists THEN it should generate the model spec', () => {
-      const mongooseModels = ['Student'];
-    
+      const mongooseModels = mongoose.modelNames();
       const mongooseModelSpecs = generateMongooseModelsSpec(mongooseModels);
-      const studentModelSpec = mongooseModelSpecs[mongooseModels.shift()];
-      /* Not asserting the spec itself, trusting mongoose-to-swagger :) */
-      expect(studentModelSpec).toBeDefined();
+      return mongooseModels.map(model => {
+        const modelSpec = mongooseModelSpecs[model];
+        /* Not asserting the spec itself, trusting mongoose-to-swagger :) */
+        return expect(modelSpec).toBeDefined();
+      });
+      
     });
   });
 });


### PR DESCRIPTION
Changes to include mongoose model as spec definitions ([Issue #45](https://github.com/mpashkovskiy/express-oas-generator/issues/46)):
* **Init** argument:` mongooseModels?: Array<string>`
* Dependency [mongoose-to-swagger](https://github.com/giddyinc/mongoose-to-swagger) to convert mongoose models to definitions (spec).
* Dev dependencies: mongoose + bson.
* README.md + Tests.