### PR TITLE
Feature/#64 warning env production

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Module to:
 * automatically generate OpenAPI (Swagger) specification for existing ExpressJS 4.x REST API applications;
 * provide Swagger UI basing on generated specification.
 
-#### WARNINING!
-Again: goal of the module is to provide baseline specification which should be reviewed and modified before exposing to REST API clients.
-Module should be used in test environment only because it can disclose sensitive information if it is running in production. See [How does it work?](#how-does-it-work) and [comment about usage](https://github.com/mpashkovskiy/express-oas-generator/issues/36#issuecomment-553040533) for more info.
-
 ## Examples
 
 * [server_basic.js](server_basic.js)

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ expressOasGenerator.init(app, {}); // to overwrite generated specification's val
 * **Important!** In order to get description of all parameters and JSON payloads you have to start using your REST API or run REST API tests against it so module can analyze requests/responses
 * Assuming you running your app on port 8000
     * Open [http://localhost:8000/api-docs](http://localhost:8000/api-docs) to see Swagger UI for your REST API. 
-    - OpenApi2 (default): [http://localhost:8000/api-docs/v2](http://localhost:8000/api-docs/v2)
-    - OpenApi3: [http://localhost:8000/api-docs/v3](http://localhost:8000/api-docs/v3)
+        - OpenApi2 (default): [http://localhost:8000/api-docs/v2](http://localhost:8000/api-docs/v2)
+        - OpenApi3: [http://localhost:8000/api-docs/v3](http://localhost:8000/api-docs/v3)
     * specification file is available [http://localhost:8000/api-spec](http://localhost:8000/api-spec). Link is prepended to description field
-    - OpenApi2 (default): [http://localhost:8000/api-spec/v2](http://localhost:8000/api-spec/v2)
-    - OpenApi3: [http://localhost:8000/api-spec/v3](http://localhost:8000/api-spec/v3)
+        - OpenApi2 (default): [http://localhost:8000/api-spec/v2](http://localhost:8000/api-spec/v2)
+        - OpenApi3: [http://localhost:8000/api-spec/v3](http://localhost:8000/api-spec/v3)
     
 Second argument of `expressOasGenerator.init(app, {})` could be either an object or a function. In case of the object generated spec will be merged with the object. In case of function it will be used to apply changes for generated spec. Example of function usage:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ where last five parameters are:
 * ['User', 'Student'] - (Optional) Mongoose models to be included as definitions. To get all just do mongoose.modelNames().
 The following peer dependencies are required to use this last argument: mongoose, mongoose-to-swagger, bson.
 * ['users', 'students'] - (Optional) Tags: Really useful to group operations (commonly by resources). All the matching paths containing the supplied tags will be grouped. If not supplied, defaults to mongoose models. See [example](https://swagger.io/docs/specification/2-0/grouping-operations-with-tags/).
-* ['production'] - (Optional) Ignored node environments (does not generate api docs).
+* ['production'] - (Optional) Ignored node environments. Middlewares are not applied when process.env.NODE_ENV is ignored. Existing api-docs and api-spec are still served.
 
 ## Advanced usage (recommended)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ expressOasGenerator.init(
   60 * 1000,
   'api-docs',
   ['User', 'Student'],
-  ['users', 'students']
+  ['users', 'students'],
+  ['production']
 )
 ```
 
@@ -73,6 +74,7 @@ where last five parameters are:
 * ['User', 'Student'] - (Optional) Mongoose models to be included as definitions. To get all just do mongoose.modelNames().
 The following peer dependencies are required to use this last argument: mongoose, mongoose-to-swagger, bson.
 * ['users', 'students'] - (Optional) Tags: Really useful to group operations (commonly by resources). All the matching paths containing the supplied tags will be grouped. If not supplied, defaults to mongoose models. See [example](https://swagger.io/docs/specification/2-0/grouping-operations-with-tags/).
+* ['production'] - (Optional) Ignored node environments (does not generate api docs).
 
 ## Advanced usage (recommended)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ expressOasGenerator.init(app, {}); // to overwrite generated specification's val
     * Open [http://localhost:8000/api-docs](http://localhost:8000/api-docs) to see Swagger UI for your REST API. 
         - OpenApi2 (default): [http://localhost:8000/api-docs/v2](http://localhost:8000/api-docs/v2)
         - OpenApi3: [http://localhost:8000/api-docs/v3](http://localhost:8000/api-docs/v3)
-    * specification file is available [http://localhost:8000/api-spec](http://localhost:8000/api-spec). Link is prepended to description field
+    * Specification file is available [http://localhost:8000/api-spec](http://localhost:8000/api-spec). Link is prepended to description field.
         - OpenApi2 (default): [http://localhost:8000/api-spec/v2](http://localhost:8000/api-spec/v2)
         - OpenApi3: [http://localhost:8000/api-spec/v3](http://localhost:8000/api-spec/v3)
     

--- a/README.md
+++ b/README.md
@@ -36,8 +36,12 @@ expressOasGenerator.init(app, {}); // to overwrite generated specification's val
 ```
 * **Important!** In order to get description of all parameters and JSON payloads you have to start using your REST API or run REST API tests against it so module can analyze requests/responses
 * Assuming you running your app on port 8000
-    * open [http://localhost:8000/api-docs](http://localhost:8000/api-docs) to see Swagger UI for your REST API
-    * specification file is available  [http://localhost:8000/api-spec](http://localhost:8000/api-spec) - link is prepended to description field
+    * Open [http://localhost:8000/api-docs](http://localhost:8000/api-docs) to see Swagger UI for your REST API. 
+    - OpenApi2 (default): [http://localhost:8000/api-docs/v2](http://localhost:8000/api-docs/v2)
+    - OpenApi3: [http://localhost:8000/api-docs/v3](http://localhost:8000/api-docs/v3)
+    * specification file is available [http://localhost:8000/api-spec](http://localhost:8000/api-spec). Link is prepended to description field
+    - OpenApi2 (default): [http://localhost:8000/api-spec/v2](http://localhost:8000/api-spec/v2)
+    - OpenApi3: [http://localhost:8000/api-spec/v3](http://localhost:8000/api-spec/v3)
     
 Second argument of `expressOasGenerator.init(app, {})` could be either an object or a function. In case of the object generated spec will be merged with the object. In case of function it will be used to apply changes for generated spec. Example of function usage:
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,9 @@ export interface HandleResponsesOptions {
 
 	/** Tags to be used */
 	tags?: Array<string>;
+
+	/** Ignored node environments */
+	ignoredNodeEnvironments?: Array<string>
 }
 
 /**
@@ -89,7 +92,8 @@ export function init(
 	writeIntervalMs?: HandleResponsesOptions['writeIntervalMs'],
 	swaggerUiServePath?: HandleResponsesOptions['swaggerUiServePath'],
 	mongooseModels?: HandleResponsesOptions['mongooseModels'],
-	tags?: HandleResponsesOptions['tags']
+	tags?: HandleResponsesOptions['tags'],
+	ignoredNodeEnvironments?: HandleResponsesOptions['ignoredNodeEnvironments']
 ): void;
 
 export const getSpec: () => object | OpenAPIV2.Document;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck	
-/* eslint-disable complexity */	
 /**
  * @fileOverview main file
  * @module index
@@ -23,8 +21,8 @@ const { logger } = require('./lib/logger');
 const DEFAULT_SWAGGER_UI_SERVE_PATH = 'api-docs';
 const DEFAULT_IGNORE_NODE_ENVIRONMENTS = ['production'];
 
-const UNDEFINED_NODE_ENV_ERROR = ignoredNodeEnvironments => `WARNING!!! process.env.NODE_ENV is not defined. 
-  To disable the module set process.env.NODE_ENV to any of the supplied ignoredNodeEnvironments: ${ignoredNodeEnvironments.join()}`;
+const UNDEFINED_NODE_ENV_ERROR = ignoredNodeEnvironments => `WARNING!!! process.env.NODE_ENV is not defined.\
+To disable the module set process.env.NODE_ENV to any of the supplied ignoredNodeEnvironments: ${ignoredNodeEnvironments.join()}`;
 
 const WRONG_MIDDLEWARE_ORDER_ERROR = `
 Express oas generator:

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-// @ts-nocheck
-/* eslint-disable complexity */
 /**
  * @fileOverview main file
  * @module index

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ const { convertOpenApiVersionToV3, getSpecByVersion, versions } = require('./lib
 const processors = require('./lib/processors');
 const listEndpoints = require('express-list-endpoints');
 
-const OPTIONS_METHOD = 'options';
-
 const DEFAULT_SWAGGER_UI_SERVE_PATH = 'api-docs';
 const DEFAULT_IGNORE_NODE_ENVIRONMENTS = ['production'];
 
@@ -257,7 +255,7 @@ function getMethod(req) {
   }
 
   const m = req.method.toLowerCase();
-  if (m === OPTIONS_METHOD) {
+  if (m === 'options') {
     return undefined;
   }
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// @ts-nocheck
+/* eslint-disable complexity */
 /**
  * @fileOverview main file
  * @module index
@@ -321,12 +323,7 @@ function handleResponses(expressApp,
     ignoredNodeEnvironments: DEFAULT_IGNORE_NODE_ENVIRONMENTS,
   }) {
 
-  
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
-  if (ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
-    return;
-  }
-
   responseMiddlewareHasBeenApplied = true;
 
   /**
@@ -342,52 +339,50 @@ function handleResponses(expressApp,
   updateDefinitionsSpec(options.mongooseModels);
   updateTagsSpec(options.tags || options.mongooseModels);
   
-  /** middleware to handle RESPONSES */
-  app.use((req, res, next) => {
-    try {
-      const methodAndPathKey = getMethod(req);
-      if (methodAndPathKey && methodAndPathKey.method) {
-        processors.processResponse(res, methodAndPathKey.method);
+  if (!ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
+    /** middleware to handle RESPONSES */
+    app.use((req, res, next) => {
+      try {
+        const methodAndPathKey = getMethod(req);
+        if (methodAndPathKey && methodAndPathKey.method) {
+          processors.processResponse(res, methodAndPathKey.method);
+        }
+
+        const ts = new Date().getTime();
+        if (firstResponseProcessing || specOutputPath && ts - lastRecordTime > writeIntervalMs) {
+          firstResponseProcessing = false;
+          lastRecordTime = ts;
+
+          fs.writeFileSync(specOutputPath, JSON.stringify(spec, null, 2), 'utf8');
+
+          convertOpenApiVersionToV3(spec, (err, specV3) => {
+            if (!err) {
+              const parsedSpecOutputPath = path.parse(specOutputPath);
+              const {name, ext} = parsedSpecOutputPath;
+              parsedSpecOutputPath.base = name.concat('_').concat(versions.OPEN_API_V3).concat(ext);
+              
+              const v3Path = path.format(parsedSpecOutputPath);
+              
+              fs.writeFileSync(v3Path, JSON.stringify(specV3), 'utf8');
+            }
+            /** TODO - Log that open api v3 could not be generated */
+          });  
+
+        }
+      } catch (e) {
+        /** TODO - shouldn't we do something here? */
+      } finally {
+        /** always call the next middleware */
+        next();
       }
-
-      const ts = new Date().getTime();
-      if (firstResponseProcessing || specOutputPath && ts - lastRecordTime > writeIntervalMs) {
-        firstResponseProcessing = false;
-        lastRecordTime = ts;
-
-        fs.writeFileSync(specOutputPath, JSON.stringify(spec, null, 2), 'utf8');
-
-        convertOpenApiVersionToV3(spec, (err, specV3) => {
-          if (!err) {
-            const parsedSpecOutputPath = path.parse(specOutputPath);
-            const {name, ext} = parsedSpecOutputPath;
-            parsedSpecOutputPath.base = name.concat('_').concat(versions.OPEN_API_V3).concat(ext);
-            
-            const v3Path = path.format(parsedSpecOutputPath);
-            
-            fs.writeFileSync(v3Path, JSON.stringify(specV3), 'utf8');
-          }
-          /** TODO - Log that open api v3 could not be generated */
-        });  
-
-      }
-    } catch (e) {
-      /** TODO - shouldn't we do something here? */
-    } finally {
-      /** always call the next middleware */
-      next();
-    }
-  });
+    });
+  }
 }
 
 /**
  * @type { typeof import('./index').handleRequests }
  */
 function handleRequests() {
-  if (ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
-    return;
-  }
-
   /** make sure the middleware placement order (by the user) is correct */
   if (responseMiddlewareHasBeenApplied !== true) {
     throw new Error(WRONG_MIDDLEWARE_ORDER_ERROR);
@@ -396,24 +391,26 @@ function handleRequests() {
   /** everything was applied correctly; reset the global variable. */
   responseMiddlewareHasBeenApplied = false;
 
-  /** middleware to handle REQUESTS */
-  app.use((req, res, next) => {
-    try {
-      const methodAndPathKey = getMethod(req);
-      if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
-        const method = methodAndPathKey.method;
-        updateSchemesAndHost(req);
-        processors.processPath(req, method, methodAndPathKey.pathKey);
-        processors.processHeaders(req, method, spec);
-        processors.processBody(req, method);
-        processors.processQuery(req, method);
+  if (!ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
+    /** middleware to handle REQUESTS */
+    app.use((req, res, next) => {
+      try {
+        const methodAndPathKey = getMethod(req);
+        if (methodAndPathKey && methodAndPathKey.method && methodAndPathKey.pathKey) {
+          const method = methodAndPathKey.method;
+          updateSchemesAndHost(req);
+          processors.processPath(req, method, methodAndPathKey.pathKey);
+          processors.processHeaders(req, method, spec);
+          processors.processBody(req, method);
+          processors.processQuery(req, method);
+        }
+      } catch (e) {
+        /** TODO - shouldn't we do something here? */
+      } finally {
+        next();
       }
-    } catch (e) {
-      /** TODO - shouldn't we do something here? */
-    } finally {
-      next();
-    }
-  });
+    });
+  }
 
   /** forward options to `serveApiDocs`: */
   serveApiDocs();

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+// @ts-nocheck	
+/* eslint-disable complexity */	
 /**
  * @fileOverview main file
  * @module index
@@ -16,9 +18,13 @@ const { generateTagsSpec, matchingTags } = require('./lib/tags');
 const { convertOpenApiVersionToV3, getSpecByVersion, versions } = require('./lib/openapi');
 const processors = require('./lib/processors');
 const listEndpoints = require('express-list-endpoints');
+const { logger } = require('./lib/logger');
 
 const DEFAULT_SWAGGER_UI_SERVE_PATH = 'api-docs';
 const DEFAULT_IGNORE_NODE_ENVIRONMENTS = ['production'];
+
+const UNDEFINED_NODE_ENV_ERROR = ignoredNodeEnvironments => `WARNING!!! process.env.NODE_ENV is not defined. 
+  To disable the module set process.env.NODE_ENV to any of the supplied ignoredNodeEnvironments: ${ignoredNodeEnvironments.join()}`;
 
 const WRONG_MIDDLEWARE_ORDER_ERROR = `
 Express oas generator:
@@ -318,6 +324,11 @@ function handleResponses(expressApp,
   }) {
 
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
+  
+  if (!process.env.NODE_ENV) {
+    logger.warn(UNDEFINED_NODE_ENV_ERROR(ignoredNodeEnvironments));
+  }
+  
   if (ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
     return;
   }
@@ -382,7 +393,7 @@ function handleRequests() {
   if (ignoredNodeEnvironments.includes(process.env.NODE_ENV)) {
     return;
   }
-
+  
   /** make sure the middleware placement order (by the user) is correct */
   if (responseMiddlewareHasBeenApplied !== true) {
     throw new Error(WRONG_MIDDLEWARE_ORDER_ERROR);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ const { convertOpenApiVersionToV3, getSpecByVersion, versions } = require('./lib
 const processors = require('./lib/processors');
 const listEndpoints = require('express-list-endpoints');
 
+const OPTIONS_METHOD = 'options';
+
 const DEFAULT_SWAGGER_UI_SERVE_PATH = 'api-docs';
 const DEFAULT_IGNORE_NODE_ENVIRONMENTS = ['production'];
 
@@ -229,11 +231,7 @@ function patchSpec(predefinedSpec) {
  * @returns {string|undefined|*}
  */
 function getPathKey(req) {
-  if (!req.url) {
-    return undefined;
-  }
-
-  if (spec.paths[req.url]) {
+  if (!req.url || spec.paths[req.url]) {
     return req.url;
   }
 
@@ -259,7 +257,7 @@ function getMethod(req) {
   }
 
   const m = req.method.toLowerCase();
-  if (m === 'options') {
+  if (m === OPTIONS_METHOD) {
     return undefined;
   }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,7 +1,13 @@
-const winston = require('winston');
+const { createLogger, format, transports } = require('winston');
+const { combine, timestamp, prettyPrint } = format;
 
-module.exports.logger = winston.createLogger({
+module.exports.logger = createLogger({
+  format: combine(
+    timestamp(),
+    prettyPrint()
+  ),
+  defaultMeta: { service: 'express-oas-generator' },
   transports: [
-    new winston.transports.Console({format: winston.format.simple()})
+    new transports.Console()
   ],
 });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,7 @@
+const winston = require('winston');
+
+module.exports.logger = winston.createLogger({
+  transports: [
+    new winston.transports.Console({format: winston.format.simple()})
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,6 +141,16 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@exodus/schemasafe": {
       "version": "1.0.0-rc.2",
       "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.2.tgz",
@@ -319,6 +329,11 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
+    },
+    "async": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+      "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -625,11 +640,19 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
     },
+    "color": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+      "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+      "requires": {
+        "color-convert": "^1.9.1",
+        "color-string": "^1.5.2"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -637,14 +660,31 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
+      "integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
       "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
       "dev": true
+    },
+    "colorspace": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+      "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+      "requires": {
+        "color": "3.0.x",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -747,8 +787,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
       "version": "3.1.0",
@@ -885,6 +924,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -1190,6 +1234,11 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
+    "fecha": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.0.tgz",
+      "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1255,6 +1304,11 @@
         "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "foreground-child": {
       "version": "1.5.6",
@@ -1587,8 +1641,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1873,6 +1926,11 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "lcov-parse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
@@ -1950,6 +2008,30 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
+    },
+    "logform": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+      "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fast-safe-stringify": "^2.0.4",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "long": {
       "version": "4.0.0",
@@ -2529,6 +2611,14 @@
         "wrappy": "1"
       }
     },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
+      }
+    },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -2702,8 +2792,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -2788,7 +2877,6 @@
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
       "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -2802,14 +2890,12 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-          "dev": true
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -3132,6 +3218,21 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
@@ -3232,6 +3333,11 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -3252,7 +3358,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -3260,8 +3365,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -3514,6 +3618,11 @@
         "require-main-filename": "^2.0.0"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -3556,6 +3665,11 @@
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
       }
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -3637,8 +3751,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -3692,6 +3805,53 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+      "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+      "requires": {
+        "readable-stream": "^2.3.7",
+        "triple-beam": "^1.2.0"
+      }
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint --ignore-pattern \"*.json\" lib/** test/** index.js",
     "jasmine": "nyc --reporter cobertura --reporter html --reporter text --report-dir ./build/test-reports/coverage node ./node_modules/jasmine/bin/jasmine.js JASMINE_CONFIG_PATH=test/_jasmine/jasmine.json",
     "cve-check": "npm audit --audit-level high",
-    "test": "npm run lint -- --fix && npm run cve-check && npm run jasmine",
+    "test": "npm run lint -- --fix && npm run cve-check && NODE_ENV=test npm run jasmine",
     "send-coverage": "nyc report --reporter=text-lcov | ./node_modules/coveralls/bin/coveralls.js",
     "pp": "npm version patch && npm publish && git push --follow-tag",
     "generate-docs": "jsdoc -c jsdoc.json"
@@ -40,7 +40,8 @@
     "openapi-types": "^1.3.5",
     "swagger-ui-express": "^3.0.8",
     "swagger2openapi": "^7.0.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.7.2",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "body-parser": "^1.18.2",

--- a/server_basic.js
+++ b/server_basic.js
@@ -14,7 +14,7 @@ const app = express();
 generator.init(app, function(spec) {
   _.set(spec, 'paths["/students/{name}"].get.parameters[0].description', 'description of a parameter');
   return spec;
-}, './test_spec.json', 1000, 'api-docs', modelNames, ['students']);
+}, './test_spec.json', 1000, 'api-docs', modelNames, ['students'], ['production']);
 
 app.use(bodyParser.json({}));
 let router = express.Router();

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -341,6 +341,16 @@ it('WHEN mongoose models are supplied THEN the definitions and tags should be in
   });
 });
 
+it('WHEN node environment is undefined THEN it should log warning ', () => {
+  const app = express();
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  delete process.env.NODE_ENV;
+  generator.handleResponses(app);
+  generator.handleRequests();
+  //Is there a way to assert winston warn output?
+  process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+});
+
 it('WHEN node environment is ignored THEN it should not generate or serve api docs/spec ', done => {
   const app = express();
   const PRODUCTION_NODE_ENV = 'production';
@@ -349,17 +359,17 @@ it('WHEN node environment is ignored THEN it should not generate or serve api do
 
   const PATH = '/path';
 
-  generator.handleResponses(app, {
-    ignoredNodeEnvironments: [PRODUCTION_NODE_ENV]
-  });
-
   app.get(PATH, (req, res, next) => {
     res.setHeader('Content-Type', 'text/plain');
     res.send(PLAIN_TEXT_RESPONSE);
     return next();
   });
 
+  generator.handleResponses(app, {
+    ignoredNodeEnvironments: [PRODUCTION_NODE_ENV]
+  });
   generator.handleRequests();
+
   app.set('port', port);
   const server = app.listen(app.get('port'), () => {
     request.get(`http://localhost:${port}/api-spec`, (error, responseApiSpec) => {

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -310,9 +310,7 @@ it('WHEN mongoose models are supplied THEN the definitions and tags should be in
     'api-spec.json',
     1000,
     'custom-docs',
-    mongooseModels,
-    mongooseModels,
-    ['production']
+    mongooseModels
   );
 
   const tag = mongooseModels.shift();

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -7,6 +7,7 @@ const mongoose = require('mongoose');
 require('./lib/mongoose_models/student');
 const generator = require('../index.js');
 const { versions } = require('../lib/openapi');
+let { logger } = require('../lib/logger');
 
 const MS_TO_STARTUP = 2000;
 const port = 8888;
@@ -343,11 +344,12 @@ it('WHEN mongoose models are supplied THEN the definitions and tags should be in
 
 it('WHEN node environment is undefined THEN it should log warning ', () => {
   const app = express();
+  const loggerSpy = spyOn(logger, 'warn').and.callThrough();
   const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
   delete process.env.NODE_ENV;
   generator.handleResponses(app);
   generator.handleRequests();
-  //Is there a way to assert winston warn output?
+  expect(loggerSpy).toHaveBeenCalled();
   process.env.NODE_ENV = ORIGINAL_NODE_ENV;
 });
 

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -310,7 +310,9 @@ it('WHEN mongoose models are supplied THEN the definitions and tags should be in
     'api-spec.json',
     1000,
     'custom-docs',
-    mongooseModels
+    mongooseModels,
+    mongooseModels,
+    ['production']
   );
 
   const tag = mongooseModels.shift();


### PR DESCRIPTION
Ignoring node environments supplied by args as `ignoredNodeEnvironments`. Defaults to `['production']`. 
Branch naming is not correct, it doesn't implement a warning, it just skips or applies middlewares based on`process.env.NODE_ENV`.

Try with examples by running:
* `NODE_ENV=production node server_basic.js`
* `NODE_ENV=production node server_advanced.js`

Updated README.md with new functionality + removing production use warning + missing openapi versions 😄.