### PR TITLE
Feature/always serve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ expressOasGenerator.init(
   'api-docs',
   ['User', 'Student'],
   ['users', 'students'],
-  ['production']
+  ['production'],
+  true
 )
 ```
 
@@ -71,6 +72,8 @@ where last five parameters are:
 The following peer dependencies are required to use this last argument: mongoose, mongoose-to-swagger, bson.
 * ['users', 'students'] - (Optional) Tags: Really useful to group operations (commonly by resources). All the matching paths containing the supplied tags will be grouped. If not supplied, defaults to mongoose models. See [example](https://swagger.io/docs/specification/2-0/grouping-operations-with-tags/).
 * ['production'] - (Optional) Ignored node environments. Middlewares are not applied when process.env.NODE_ENV is ignored. Existing api-docs and api-spec are still served.
+* true - (Optional) Always serve docs. In case you don't want to apply middelwares but still serve existing api-docs and api-spec.
+
 
 ## Advanced usage (recommended)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,9 @@ export interface HandleResponsesOptions {
 
 	/** Ignored node environments */
 	ignoredNodeEnvironments?: Array<string>
+
+	/** Always serve api docs */
+	alwaysServeDocs?: boolean
 }
 
 /**
@@ -93,7 +96,8 @@ export function init(
 	swaggerUiServePath?: HandleResponsesOptions['swaggerUiServePath'],
 	mongooseModels?: HandleResponsesOptions['mongooseModels'],
 	tags?: HandleResponsesOptions['tags'],
-	ignoredNodeEnvironments?: HandleResponsesOptions['ignoredNodeEnvironments']
+	ignoredNodeEnvironments?: HandleResponsesOptions['ignoredNodeEnvironments'],
+	alwaysServeDocs?: HandleResponsesOptions['alwaysServeDocs']
 ): void;
 
 export const getSpec: () => object | OpenAPIV2.Document;

--- a/server_advanced.js
+++ b/server_advanced.js
@@ -17,7 +17,8 @@ generator.handleResponses(app, {
     return spec;
   },
   specOutputPath: './test_spec.json',
-  mongooseModels: modelNames
+  mongooseModels: modelNames,
+  alwaysServeDocs: true
 });
 
 app.use(bodyParser.json({}));


### PR DESCRIPTION
Complementing PR #69. 

Including `alwaysServeDocs` argument to both `init` and `handleResponses`.
From https://github.com/mpashkovskiy/express-oas-generator/pull/69#discussion_r492490978:

- undefined - default - rely on ignoreNodeEnvironments
- true - serve spec
- false - don't serve the spec