### PR TITLE
First/last requests are not handled

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,14 +51,11 @@ let app;
 let swaggerUiServePath;
 let predefinedSpec;
 let spec = {};
-let lastRecordTime = new Date().getTime();
-let firstResponseProcessing = true;
 let mongooseModelsSpecs;
 let tagsSpecs;
 let ignoredNodeEnvironments;
 let serveDocs;
 let specOutputPath;
-let writeIntervalMs;
 
 /**
  * @param {boolean} [responseMiddlewareHasBeenApplied=false]
@@ -314,11 +311,7 @@ function updateTagsSpec(tags) {
  * @description Persists OpenAPI content to spec output file
  */
 function writeSpecToOutputFile() {
-  const ts = new Date().getTime();
-  if (firstResponseProcessing || specOutputPath && ts - lastRecordTime > writeIntervalMs) {
-    firstResponseProcessing = false;
-    lastRecordTime = ts;
-
+  if (specOutputPath) {
     fs.writeFileSync(specOutputPath, JSON.stringify(spec, null, 2), 'utf8');
 
     convertOpenApiVersionToV3(spec, (err, specV3) => {
@@ -345,7 +338,7 @@ function handleResponses(expressApp,
     swaggerUiServePath: DEFAULT_SWAGGER_UI_SERVE_PATH, 
     specOutputPath: undefined, 
     predefinedSpec: {}, 
-    writeIntervalMs: 1000 * 10, 
+    writeIntervalMs: 0, 
     mongooseModels: [], 
     tags: undefined,
     ignoredNodeEnvironments: DEFAULT_IGNORE_NODE_ENVIRONMENTS,
@@ -373,8 +366,7 @@ function handleResponses(expressApp,
   swaggerUiServePath = options.swaggerUiServePath || DEFAULT_SWAGGER_UI_SERVE_PATH;
   predefinedSpec = options.predefinedSpec || {};
   specOutputPath = options.specOutputPath;
-  writeIntervalMs = options.writeIntervalMs;
-
+  
   updateDefinitionsSpec(options.mongooseModels);
   updateTagsSpec(options.tags || options.mongooseModels);
   
@@ -462,7 +454,7 @@ function handleRequests() {
 /**
  * @type { typeof import('./index').init }
  */
-function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 1000 * 10, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined) {
+function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined) {
   handleResponses(aApp, {
     swaggerUiServePath: aSwaggerUiServePath,
     specOutputPath: aSpecOutputPath,

--- a/index.js
+++ b/index.js
@@ -391,7 +391,7 @@ function handleResponses(expressApp,
       if (methodAndPathKey && methodAndPathKey.method) {
         processors.processResponse(res, methodAndPathKey.method);
       }
-      //writeSpecToOutputFile();
+      writeSpecToOutputFile();
     } catch (e) {
       /** TODO - shouldn't we do something here? */
     } finally {

--- a/index.js
+++ b/index.js
@@ -381,9 +381,11 @@ function handleResponses(expressApp,
     try {
       const methodAndPathKey = getMethod(req);
       if (methodAndPathKey && methodAndPathKey.method) {
-        processors.processResponse(res, methodAndPathKey.method);
+        processors.processResponse(res, methodAndPathKey.method, () => {
+          writeSpecToOutputFile();
+        });
       }
-      writeSpecToOutputFile();
+      
     } catch (e) {
       /** TODO - shouldn't we do something here? */
     } finally {

--- a/lib/processors.js
+++ b/lib/processors.js
@@ -219,7 +219,7 @@ function isCompressed(res) {
  * @param res
  * @param method
  */
-module.exports.processResponse = (res, method) => {
+module.exports.processResponse = (res, method, onResponseEnd) => {
   const oldWrite = res.write;
   const oldEnd = res.end;
   const chunks = [];
@@ -245,6 +245,7 @@ module.exports.processResponse = (res, method) => {
       }
     } finally {
       oldEnd.apply(res, arguments);
+      onResponseEnd();
     }
   };
 };

--- a/test/lib/processors_tests.js
+++ b/test/lib/processors_tests.js
@@ -119,15 +119,16 @@ describe('processors.js', () => {
       };
       let method = {};
       const json = { a: 1 };
-      processors.processResponse(res, method);
-      res.write(JSON.stringify(json));
-      res.end('');
-      expect(write).toHaveBeenCalled();
-      expect(end).toHaveBeenCalled();
-      expect(method.produces).toEqual([appJson]);
-      expect(Object.keys(method.responses)).toEqual(['200']);
-      expect(method.responses['200'].schema).not.toBe(undefined);
-      expect(method.responses['200'].description).toBe('OK');
+      processors.processResponse(res, method, () => {
+        res.write(JSON.stringify(json));
+        res.end('');
+        expect(write).toHaveBeenCalled();
+        expect(end).toHaveBeenCalled();
+        expect(method.produces).toEqual([appJson]);
+        expect(Object.keys(method.responses)).toEqual(['200']);
+        expect(method.responses['200'].schema).not.toBe(undefined);
+        expect(method.responses['200'].description).toBe('OK');
+      });
     });
 
   });


### PR DESCRIPTION
Addresses bugs #50 and #55.
Tests still working when changing the `writeSpecToOutputFile` call to `handleRequests` (instead of `handleResponses`).
I've commented out the call in `handleResponses` in case you want to write in both cases.