### PR TITLE
Feat/#52 preserve spec output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ expressOasGenerator.init(
   ['User', 'Student'],
   ['users', 'students'],
   ['production'],
-  true
+  true,
+  SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE
 )
 ```
 
-where last five parameters are:
+where the last parameters are:
 * 'path/to/a/file/filename.json' - (Optional) path to a file and file name, if missing module won't write spec to the disc
 * 60 * 1000 - (Optional) write interval in milliseconds (default: 10 seconds)
 * 'api-docs' - (Optional) Swagger UI path for your REST API (default: api-docs)
@@ -73,7 +74,7 @@ The following peer dependencies are required to use this last argument: mongoose
 * ['users', 'students'] - (Optional) Tags: Really useful to group operations (commonly by resources). All the matching paths containing the supplied tags will be grouped. If not supplied, defaults to mongoose models. See [example](https://swagger.io/docs/specification/2-0/grouping-operations-with-tags/).
 * ['production'] - (Optional) Ignored node environments. Middlewares are not applied when process.env.NODE_ENV is ignored. Existing api-docs and api-spec are still served.
 * true - (Optional) Always serve docs. In case you don't want to apply middelwares but still serve existing api-docs and api-spec.
-
+* ```SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE``` - (Optional) Enum to indicate if the spec outfile file is recreated or preserved from current content (```SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE```)
 
 ## Advanced usage (recommended)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,13 +8,18 @@
  */
 
 import { Express } from 'express';
-import { OpenAPIV2,OpenAPIV3 } from 'openapi-types';
+import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
 
 /** re-export for ease of use for the end user */
 export {
 	OpenAPIV2,
 	OpenAPIV3
 };
+
+export enum SPEC_OUTPUT_FILE_BEHAVIOR {
+	PRESERVE = 'PRESERVE',
+	RECREATE = 'RECREATE'
+}
 
 /** Options for `handleResponses` */
 export interface HandleResponsesOptions {
@@ -29,9 +34,9 @@ export interface HandleResponsesOptions {
 	specOutputPath?: string;
 
 	/** either the Swagger specification or a function with one argument, which returns the spec */
-	predefinedSpec?: object | OpenAPIV2.Document | OpenAPIV3.Document | 
-		((spec: OpenAPIV2.Document) => OpenAPIV2.Document) | 
-		((spec: OpenAPIV3.Document) => OpenAPIV3.Document);
+	predefinedSpec?: object | OpenAPIV2.Document | OpenAPIV3.Document |
+	((spec: OpenAPIV2.Document) => OpenAPIV2.Document) |
+	((spec: OpenAPIV3.Document) => OpenAPIV3.Document);
 
 	/** how often to write the openAPI specification to file */
 	writeIntervalMs?: number;
@@ -47,6 +52,8 @@ export interface HandleResponsesOptions {
 
 	/** Always serve api docs */
 	alwaysServeDocs?: boolean
+
+	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ export interface HandleResponsesOptions {
 	/** Always serve api docs */
 	alwaysServeDocs?: boolean
 
-	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR
+	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -317,12 +317,14 @@ function updateTagsSpec(tags) {
  * Based on SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE or SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE
  */
 function loadSpecOutputPathContent() {
-  if (specOutputFileBehavior === SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE) {
-    if (fs.existsSync(specOutputPath)) {
-      const specOutputFileContent = fs.readFileSync(specOutputPath).toString();
-      predefinedSpec = JSON.parse(specOutputFileContent);
-    }
+  if (specOutputFileBehavior !== SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE) {
+    return;
   }
+  if (!fs.existsSync(specOutputPath)) {
+    return;
+  }
+  const specOutputFileContent = fs.readFileSync(specOutputPath).toString();
+  predefinedSpec = JSON.parse(specOutputFileContent);
 }
 
 /**
@@ -365,7 +367,7 @@ function handleResponses(expressApp,
   }) {
 
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
-  const isEnvironmentIgnored = ignoredNodeEnvironments.includes(process.env.NODE_ENV);
+  const isEnvironmentIgnored = ignoredNodeEnvironments.includes(process.env.NODE_ENV || '');
   serveDocs = options.alwaysServeDocs;
   
   if (serveDocs === undefined) {

--- a/server_advanced.js
+++ b/server_advanced.js
@@ -9,6 +9,7 @@ const zlib = require('zlib');
 require('./test/lib/mongoose_models/student');
 const mongoose = require('mongoose');
 const modelNames = mongoose.modelNames();
+const { SPEC_OUTPUT_FILE_BEHAVIOR } = generator;
 
 const app = express();
 generator.handleResponses(app, {
@@ -18,7 +19,8 @@ generator.handleResponses(app, {
   },
   specOutputPath: './test_spec.json',
   mongooseModels: modelNames,
-  alwaysServeDocs: true
+  alwaysServeDocs: true,
+  specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE
 });
 
 app.use(bodyParser.json({}));
@@ -50,7 +52,9 @@ router.route('/gzip')
     });
   });
 app.use(router);
+app.disable('etag');
 app.set('port', 8080);
+
 generator.handleRequests();
 app.listen(app.get('port'), function() {
   console.log('Server started. Open http://localhost:8080/api-docs/');

--- a/server_basic.js
+++ b/server_basic.js
@@ -9,12 +9,13 @@ const zlib = require('zlib');
 require('./test/lib/mongoose_models/student');
 const mongoose = require('mongoose');
 const modelNames = mongoose.modelNames();
+const { SPEC_OUTPUT_FILE_BEHAVIOR } = generator;
 
 const app = express();
 generator.init(app, function(spec) {
   _.set(spec, 'paths["/students/{name}"].get.parameters[0].description', 'description of a parameter');
   return spec;
-}, './test_spec.json', 1000, 'api-docs', modelNames, ['students'], ['production']);
+}, './test_spec.json', 1000, 'api-docs', modelNames, ['students'], ['production'], SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE);
 
 app.use(bodyParser.json({}));
 let router = express.Router();

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -430,7 +430,7 @@ it('WHEN node environment is ignored but always serve docs is enabled THEN it sh
 
 it('WHEN specOutputFileBehavior is set to PRESERVE THEN it should load existing spec file', () => {
   const app = express();
-  const specOutputPath = './test/outputs/test_spec.json';
+  const specOutputPath = './test/outputs/example_spec.json';
   generator.handleResponses(app, {
     specOutputPath,
     specOutputFileBehavior: generator.SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -4,6 +4,7 @@ const express = require('express');
 const request = require('request');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
+const fs = require('fs');
 require('./lib/mongoose_models/student');
 const generator = require('../index.js');
 const { versions } = require('../lib/openapi');
@@ -425,6 +426,18 @@ it('WHEN node environment is ignored but always serve docs is enabled THEN it sh
       });
     });
   });
+});
+
+it('WHEN specOutputFileBehavior is set to PRESERVE THEN it should load existing spec file', () => {
+  const app = express();
+  const specOutputPath = './test/outputs/test_spec.json';
+  generator.handleResponses(app, {
+    specOutputPath,
+    specOutputFileBehavior: generator.SPEC_OUTPUT_FILE_BEHAVIOR.PRESERVE
+  });
+  generator.handleRequests();
+  const specOutputFileContent = fs.readFileSync(specOutputPath).toString();
+  expect(JSON.parse(specOutputFileContent)).toEqual(generator.getSpec());
 });
 
 it('WHEN **request** middleware is injected before **response** middleware THEN an error should be thrown', done => {

--- a/test/outputs/example_spec.json
+++ b/test/outputs/example_spec.json
@@ -1,0 +1,100 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/students/stranger": {
+      "get": {
+        "summary": "/students/stranger",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {},
+        "tags": [
+          "Student"
+        ]
+      }
+    },
+    "/students/{name}": {
+      "get": {
+        "summary": "/students/{name}",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "description of a parameter",
+            "type": "string",
+            "example": "test"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string",
+                  "example": "hello test"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Student"
+        ],
+        "produces": [
+          "application/json"
+        ]
+      }
+    },
+    "/gzip": {
+      "get": {
+        "summary": "/gzip",
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {},
+        "tags": []
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Student"
+    }
+  ],
+  "definitions": {
+    "Student": {
+      "title": "Student",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "_id": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "info": {
+    "title": "express-oas-generator",
+    "version": "1.0.32",
+    "license": {
+      "name": "ISC"
+    },
+    "description": "Specification JSONs: [v2](/api-spec/v2), [v3](/api-spec/v3).\n\nModule to automatically generate OpenAPI (Swagger) specification for existing ExpressJS 4.x REST API applications"
+  },
+  "schemes": [
+    "http"
+  ],
+  "host": "localhost:8080"
+}


### PR DESCRIPTION
Including an additional enum argument `SPEC_OUTPUT_FILE_BEHAVIOR` that defines if you either:

- `PRESERVE`: Loads existing spec file on startup.
- `RECREATE` (default, current behavior): Overwrites existing file with empty spec.

I fixed a few linting and formatting issues by the way, if you want I can rollback and do a separate PR.