### PR TITLE
feat: add parameter to edit  swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Here is a sample
 This library uses [swagger-ui-express](https://github.com/scottie1984/swagger-ui-express) as dependency , so if you need to edit the swagger's default documentation page style you can set `swaggerDocumentOptions`. This option receives any [custom swagger options](https://github.com/scottie1984/swagger-ui-express#custom-swagger-options) and pass through when swaggerUi are configured.
 
 You can follow these links to see how settings can be edited:
--> [Custom CSS styles](https://github.com/scottie1984/swagger-ui-express#custom-css-styles)
--> [Custom CSS styles from Url](https://github.com/scottie1984/swagger-ui-express#custom-css-styles-from-url)
--> [Custom JS](https://github.com/scottie1984/swagger-ui-express#custom-js)
--> And for all the available options, refer to [Swagger UI Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
+* [Custom CSS styles](https://github.com/scottie1984/swagger-ui-express#custom-css-styles)
+* [Custom CSS styles from Url](https://github.com/scottie1984/swagger-ui-express#custom-css-styles-from-url)
+* [Custom JS](https://github.com/scottie1984/swagger-ui-express#custom-js)
+* And for all the available options, refer to [Swagger UI Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
 
 An basic example is:
 ```

--- a/README.md
+++ b/README.md
@@ -146,6 +146,25 @@ Here is a sample
 }
 ```
 
+## (Optional) Edit Swagger Document Options
+
+This library uses [swagger-ui-express](https://github.com/scottie1984/swagger-ui-express) as dependency , so if you need to edit the swagger's default documentation page style you can set `swaggerDocumentOptions`. This option receives any [custom swagger options](https://github.com/scottie1984/swagger-ui-express#custom-swagger-options) and pass through when swaggerUi are configured.
+
+You can follow these links to see how settings can be edited:
+-> [Custom CSS styles](https://github.com/scottie1984/swagger-ui-express#custom-css-styles)
+-> [Custom CSS styles from Url](https://github.com/scottie1984/swagger-ui-express#custom-css-styles-from-url)
+-> [Custom JS](https://github.com/scottie1984/swagger-ui-express#custom-js)
+-> And for all the available options, refer to [Swagger UI Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)
+
+An basic example is:
+```
+generator.handleResponses(app, {
+    swaggerDocumentOptions: { customCss: '.swagger-ui { background-color: red }' }
+  });
+```
+And that would result in this:
+![image](https://user-images.githubusercontent.com/3339092/121407754-0721ba80-c936-11eb-9aa0-d1bd32152e20.png)
+
 ## Rationale
 
 Goal of the module is to provide developers with Swagger UI in development environments. Module process every request and response therefore it may slow down your app - is not supposed to be used in production environment.

--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export interface HandleResponsesOptions {
 
 	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string;
 
-  swaggerDocumentOptions: SwaggerUiOptions;
+	swaggerDocumentOptions: SwaggerUiOptions;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,6 +54,8 @@ export interface HandleResponsesOptions {
 	alwaysServeDocs?: boolean
 
 	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string
+
+  swaggerDocumentOptions?: object
 }
 
 /**
@@ -104,7 +106,8 @@ export function init(
 	mongooseModels?: HandleResponsesOptions['mongooseModels'],
 	tags?: HandleResponsesOptions['tags'],
 	ignoredNodeEnvironments?: HandleResponsesOptions['ignoredNodeEnvironments'],
-	alwaysServeDocs?: HandleResponsesOptions['alwaysServeDocs']
+	alwaysServeDocs?: HandleResponsesOptions['alwaysServeDocs'],
+	swaggerDocumentOptions?: HandleResponsesOptions['swaggerDocumentOptions']
 ): void;
 
 export const getSpec: () => object | OpenAPIV2.Document;

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ export interface HandleResponsesOptions {
 
 	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string
 
-  swaggerDocumentOptions?: object
+  swaggerDocumentOptions: Array<string>
 }
 
 /**
@@ -107,6 +107,7 @@ export function init(
 	tags?: HandleResponsesOptions['tags'],
 	ignoredNodeEnvironments?: HandleResponsesOptions['ignoredNodeEnvironments'],
 	alwaysServeDocs?: HandleResponsesOptions['alwaysServeDocs'],
+	specOutputFileBehavior?: HandleResponsesOptions['specOutputFileBehavior'],
 	swaggerDocumentOptions?: HandleResponsesOptions['swaggerDocumentOptions']
 ): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,11 +9,13 @@
 
 import { Express } from 'express';
 import { OpenAPIV2, OpenAPIV3 } from 'openapi-types';
+import { SwaggerUiOptions } from "swagger-ui-express"
 
 /** re-export for ease of use for the end user */
 export {
 	OpenAPIV2,
-	OpenAPIV3
+	OpenAPIV3,
+	SwaggerUiOptions
 };
 
 export enum SPEC_OUTPUT_FILE_BEHAVIOR {
@@ -48,14 +50,14 @@ export interface HandleResponsesOptions {
 	tags?: Array<string>;
 
 	/** Ignored node environments */
-	ignoredNodeEnvironments?: Array<string>
+	ignoredNodeEnvironments?: Array<string>;
 
 	/** Always serve api docs */
-	alwaysServeDocs?: boolean
+	alwaysServeDocs?: boolean;
 
-	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string
+	specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR | string;
 
-  swaggerDocumentOptions: Array<string>
+  swaggerDocumentOptions: SwaggerUiOptions;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ let ignoredNodeEnvironments;
 let serveDocs;
 let specOutputPath;
 let specOutputFileBehavior;
+let swaggerDocumentOptions;
 
 /**
  * @param {boolean} [responseMiddlewareHasBeenApplied=false]
@@ -139,7 +140,7 @@ function swaggerServeMiddleware(version) {
     getSpecByVersion(spec, version, (err, openApiSpec) => {
       if (!err) {
         res.setHeader('Content-Type', 'text/html');
-        swaggerUi.setup(openApiSpec)(req, res);
+        swaggerUi.setup(openApiSpec, swaggerDocumentOptions)(req, res);
       }
     });
   };
@@ -367,7 +368,8 @@ function handleResponses(expressApp,
     tags: undefined,
     ignoredNodeEnvironments: DEFAULT_IGNORE_NODE_ENVIRONMENTS,
     alwaysServeDocs: undefined,
-    specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE
+    specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
+    swaggerDocumentOptions: {}
   }) {
 
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
@@ -392,6 +394,7 @@ function handleResponses(expressApp,
   predefinedSpec = options.predefinedSpec || {};
   specOutputPath = options.specOutputPath;
   specOutputFileBehavior = options.specOutputFileBehavior;
+  swaggerDocumentOptions = options.swaggerDocumentOptions;
   
   loadSpecOutputPathContent();
   updateDefinitionsSpec(options.mongooseModels);
@@ -487,7 +490,7 @@ function handleRequests() {
 /**
  * @type { typeof import('./index').init }
  */
-function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE) {
+function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSwaggerDocumentOptions = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE) {
   handleResponses(aApp, {
     swaggerUiServePath: aSwaggerUiServePath,
     specOutputPath: aSpecOutputPath,
@@ -497,6 +500,7 @@ function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInt
     tags: aTags,
     ignoredNodeEnvironments: aIgnoredNodeEnvironments,
     alwaysServeDocs: aAlwaysServeDocs,
+    swaggerDocumentOptions: aSwaggerDocumentOptions,
     specOutputFileBehavior: aSpecOutputFileBehavior
   });
   setTimeout(() => handleRequests(), 1000);

--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ let ignoredNodeEnvironments;
 let serveDocs;
 let specOutputPath;
 let specOutputFileBehavior;
+/**
+ * @type { typeof import('./index').SwaggerUiOptions }
+*/
 let swaggerDocumentOptions;
 
 /**
@@ -369,7 +372,7 @@ function handleResponses(expressApp,
     ignoredNodeEnvironments: DEFAULT_IGNORE_NODE_ENVIRONMENTS,
     alwaysServeDocs: undefined,
     specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
-    swaggerDocumentOptions: []
+    swaggerDocumentOptions: {}
   }) {
 
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
@@ -490,7 +493,7 @@ function handleRequests() {
 /**
  * @type { typeof import('./index').init }
  */
-function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE, aSwaggerDocumentOptions = []) {
+function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE, aSwaggerDocumentOptions = {}) {
   handleResponses(aApp, {
     swaggerUiServePath: aSwaggerUiServePath,
     specOutputPath: aSpecOutputPath,

--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ function handleResponses(expressApp,
     ignoredNodeEnvironments: DEFAULT_IGNORE_NODE_ENVIRONMENTS,
     alwaysServeDocs: undefined,
     specOutputFileBehavior: SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE,
-    swaggerDocumentOptions: {}
+    swaggerDocumentOptions: []
   }) {
 
   ignoredNodeEnvironments = options.ignoredNodeEnvironments || DEFAULT_IGNORE_NODE_ENVIRONMENTS;
@@ -490,7 +490,7 @@ function handleRequests() {
 /**
  * @type { typeof import('./index').init }
  */
-function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSwaggerDocumentOptions = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE) {
+function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInterval = 0, aSwaggerUiServePath = DEFAULT_SWAGGER_UI_SERVE_PATH, aMongooseModels = [], aTags = undefined, aIgnoredNodeEnvironments = DEFAULT_IGNORE_NODE_ENVIRONMENTS, aAlwaysServeDocs = undefined, aSpecOutputFileBehavior = SPEC_OUTPUT_FILE_BEHAVIOR.RECREATE, aSwaggerDocumentOptions = []) {
   handleResponses(aApp, {
     swaggerUiServePath: aSwaggerUiServePath,
     specOutputPath: aSpecOutputPath,
@@ -500,8 +500,8 @@ function init(aApp, aPredefinedSpec = {}, aSpecOutputPath = undefined, aWriteInt
     tags: aTags,
     ignoredNodeEnvironments: aIgnoredNodeEnvironments,
     alwaysServeDocs: aAlwaysServeDocs,
-    swaggerDocumentOptions: aSwaggerDocumentOptions,
-    specOutputFileBehavior: aSpecOutputFileBehavior
+    specOutputFileBehavior: aSpecOutputFileBehavior,
+    swaggerDocumentOptions: aSwaggerDocumentOptions
   });
   setTimeout(() => handleRequests(), 1000);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,6 +242,16 @@
         "@types/mime": "*"
       }
     },
+    "@types/swagger-ui-express": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.2.tgz",
+      "integrity": "sha512-t9teFTU8dKe69rX9EwL6OM2hbVquYdFM+sQ0REny4RalPlxAm+zyP04B12j4c7qEuDS6CnlwICywqWStPA3v4g==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "winston": "^3.3.3"
   },
   "devDependencies": {
+    "@types/swagger-ui-express": "^4.1.2",
     "body-parser": "^1.18.2",
     "bson": "^4.0.4",
     "coveralls": "^3.0.0",

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -483,3 +483,60 @@ it('WHEN middleware order is correct THEN no errors should be thrown', done => {
 
   done();
 });
+
+it('WHEN swaggerDocumentOptions is set with custom css .handleResponses()', done => {
+  const app = express();
+  const specOutputPath = './test/outputs/example_spec.json';
+
+  generator.handleResponses(app, {
+    specOutputPath,
+    swaggerDocumentOptions: { customCss: '.customCssClass { display: none }' }
+  });
+
+  generator.handleRequests();
+
+  app.set('port', port);
+  const server = app.listen(app.get('port'), () => {
+    setTimeout(() => {
+      request.get(`http://localhost:${port}/api-docs`, (error, response) => {
+        expect(error).toBeNull();
+        expect(response.statusCode).toBe(200);
+        expect(response.body.includes('.customCssClass { display: none }')).toBeTruthy();
+        server.close();
+        done();
+      });
+    }, MS_TO_STARTUP);
+  });
+});
+
+
+it('WHEN swaggerDocumentOptions is set with custom css .init()', done => {
+  const app = express();
+  const mongooseModels = mongoose.modelNames();
+  
+  generator.init(
+    app,
+    spec => spec,
+    'api-spec.json',
+    1000,
+    'api-docs',
+    mongooseModels,
+    null,
+    null,
+    null,
+    { customCss: '.customCssClass { display: none }' }
+  );
+
+  app.set('port', port);
+  const server = app.listen(app.get('port'), () => {
+    setTimeout(() => {
+      request.get(`http://localhost:${port}/api-docs`, (error, response) => {
+        expect(error).toBeNull();
+        expect(response.statusCode).toBe(200);
+        expect(response.body.includes('.customCssClass { display: none }')).toBeTruthy();
+        server.close();
+        done();
+      });
+    }, MS_TO_STARTUP);
+  });
+});

--- a/test/index_tests.js
+++ b/test/index_tests.js
@@ -524,6 +524,7 @@ it('WHEN swaggerDocumentOptions is set with custom css .init()', done => {
     null,
     null,
     null,
+    null,
     { customCss: '.customCssClass { display: none }' }
   );
 


### PR DESCRIPTION
Hi
in order to improve the usability of the library, I feel free to open this pull request

I found myself needing to edit the swagger's default documentation page style.
So, ensuring that this library uses swagger-ui-express as dependency I made this implementation that add new option to receives the [custom swagger options](https://github.com/scottie1984/swagger-ui-express#custom-swagger-options), and pass through when swaggerUi are configured.

This enables the following documentation settings can be edited:
-> [Custom CSS styles](https://github.com/scottie1984/swagger-ui-express#custom-css-styles)
-> [Custom CSS styles from Url](https://github.com/scottie1984/swagger-ui-express#custom-css-styles-from-url)
-> [Custom JS](https://github.com/scottie1984/swagger-ui-express#custom-js)
-> And for all the available options, refer to [Swagger UI Configuration](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md)

As example, the way to use it would be:
```
generator.handleResponses(app, {
    swaggerDocumentOptions: { customCss: '.swagger-ui { background-color: red }' }
  });
```
And that would result in this swagger docs page:
![image](https://user-images.githubusercontent.com/3339092/121407754-0721ba80-c936-11eb-9aa0-d1bd32152e20.png)

